### PR TITLE
introduce datatarget_feedback

### DIFF
--- a/micropsi_core/nodenet/node.py
+++ b/micropsi_core/nodenet/node.py
@@ -296,6 +296,7 @@ class Gate(object):  # todo: take care of gate functions at the level of nodespa
     @activation.setter
     def activation(self, activation):
         self.sheaves['default'].activation = activation
+        self.node.report_gate_activation('gen', self.sheaves['default'])
 
     def __init__(self, type, node, sheaves=None, gate_function=None, parameters=None, gate_defaults=None):
         """create a gate.

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -16,15 +16,17 @@ def actor(netapi, node=None, datatarget=None, **params):
         return
     activation_to_set = node.get_slot("gen").activation
     netapi.world.set_datatarget(netapi.uid, datatarget, activation_to_set)
-    # TODO: check if we want to incorporate world feedback here instead of just confirming the write
-    if activation_to_set > 0:
-        node.activation = 1
+    # if activation_to_set > 0:
+        # node.activation = 1
+    feedback = netapi.world.get_datatarget_feedback(netapi.uid, datatarget)
+    node.get_gate('gen').activation = feedback if feedback else -1
 
 
 def concept(netapi, node=None, **params):
     node.activation = node.get_slot("gen").activation
     for type, gate in node.gates.items():
         gate.gate_function(node.get_slot("gen").activation)
+
 
 def script(netapi, node=None, **params):
     """ Script nodes are state machines that use the node activation for determining their behavior.

--- a/micropsi_core/world/island/island.py
+++ b/micropsi_core/world/island/island.py
@@ -157,6 +157,9 @@ class Braitenberg(WorldAdapter):
             r_wheel_speed *= f
             l_wheel_speed *= f
 
+        self.set_datatarget_feedback('engine_r', r_wheel_speed)
+        self.set_datatarget_feedback('engine_l', l_wheel_speed)
+
         rotation = math.degrees((l_wheel_speed - r_wheel_speed) / (self.diameter))
         translation = _2d_rotate((0, (r_wheel_speed + l_wheel_speed) / 2), rotation)
         self.orientation += rotation

--- a/micropsi_core/world/world.py
+++ b/micropsi_core/world/world.py
@@ -306,6 +306,11 @@ class World(object):
         if nodenet_uid in self.agents:
             return self.agents[nodenet_uid].set_datatarget(key, value)
 
+    def get_datatarget_feedback(self, nodenet_uid, key):
+        """allows the nodenet to write a value to a datatarget"""
+        if nodenet_uid in self.agents:
+            return self.agents[nodenet_uid].get_datatarget_feedback(key)
+
 
 # imports of individual world types:
 try:

--- a/micropsi_core/world/worldadapter.py
+++ b/micropsi_core/world/worldadapter.py
@@ -32,6 +32,7 @@ class WorldAdapter(WorldObject):
 
     datasources = {}
     datatargets = {}
+    datatarget_feedback = {}
 
     datasource_lock = Lock()
     datasource_snapshots = {}
@@ -46,6 +47,7 @@ class WorldAdapter(WorldObject):
         for key in self.datatargets:
             if key in data.get('datatargets', {}):
                 self.datatargets[key] = data['datatargets'][key]
+                self.datatarget_feedback[key] = 0
 
     # agent facing methods:
     def snapshot(self):
@@ -63,15 +65,20 @@ class WorldAdapter(WorldObject):
 
     def get_datasource(self, key):
         """allows the agent to read a value from a datasource"""
-        if key in self.datasource_snapshots:
-            return self.datasource_snapshots[key]
-        return None
+        return self.datasource_snapshots.get(key)
 
     def set_datatarget(self, key, value):
         """allows the agent to write a value to a datatarget"""
         if key in self.datatargets:
             self.datatargets[key] = value
 
+    def get_datatarget_feedback(self, key):
+        """get feedback whether the actor-induced action succeeded"""
+        return self.datatarget_feedback.get(key, 0)
+
+    def set_datatarget_feedback(self, key, value):
+        """set feedback for the given datatarget"""
+        self.datatarget_feedback[key] = value
 
     # world facing methods:
     def update(self):


### PR DESCRIPTION
worldadapters and actors now support datatarget_feedback to communicate the outcome of an action back to the nodenet.
actors will read the feedback values within their nodefunctions, the worldadapter should set them when the world is stepped
