### PR TITLE
New netapi method: unlink_direction

### DIFF
--- a/micropsi_core/nodenet/nodenet.py
+++ b/micropsi_core/nodenet/nodenet.py
@@ -898,6 +898,24 @@ class NetAPI(object):
         for uid in links_to_delete:
             self.__nodenet.delete_link(uid)
 
+    def unlink_direction(self, node, gateslot=None):
+        """
+        Deletes all links from a node ending at the given gate or originating at the given slot
+        Read this as 'delete all por linkage from this node'
+        """
+        links_to_delete = set()
+        for gatetype, gateobject in node.gates.items():
+            if gateslot is None or gateslot == gatetype:
+                for linkid, link in gateobject.outgoing.items():
+                    links_to_delete.add(linkid)
+        for slottype, slotobject in node.slots.items():
+            if gateslot is None or gateslot == slottype:
+                for linkid, link in slotobject.incoming.items():
+                    links_to_delete.add(linkid)
+
+        for uid in links_to_delete:
+            self.__nodenet.delete_link(uid)
+
     def link_actor(self, node, datatarget, weight=1, certainty=1, gate='sub', slot='sur'):
         """
         Links a node to an actor. If no actor exists in the node's nodespace for the given datatarget,

--- a/micropsi_core/tests/test_node_netapi.py
+++ b/micropsi_core/tests/test_node_netapi.py
@@ -567,6 +567,38 @@ def test_node_netapi_unlink_gate(fixed_nodenet):
     assert len(n_d.get_slot('por').incoming) == 3
 
 
+def test_node_netapi_unlink_direction(fixed_nodenet):
+    # test unlinking a gate
+    net, netapi, source = prepare(fixed_nodenet)
+    n_head = netapi.create_node("Pipe", "Root", "Head")
+    n_a = netapi.create_node("Pipe", "Root", "A")
+    n_b = netapi.create_node("Pipe", "Root", "B")
+    n_c = netapi.create_node("Pipe", "Root", "C")
+
+    netapi.link_with_reciprocal(n_head, n_a, "subsur")
+    netapi.link_with_reciprocal(n_head, n_b, "subsur")
+    netapi.link_with_reciprocal(n_head, n_c, "subsur")
+    netapi.link_full([n_a, n_b, n_c])
+
+    netapi.unlink_direction(n_b, "por")
+
+    assert len(n_head.get_gate('sub').outgoing) == 3
+    assert len(n_head.get_slot('sur').incoming) == 3
+
+    assert len(n_a.get_slot('por').incoming) == 2
+    assert len(n_b.get_slot('por').incoming) == 0
+    assert len(n_c.get_slot('por').incoming) == 2
+
+    netapi.unlink_direction(n_head, "sub")
+
+    assert len(n_head.get_gate('sub').outgoing) == 0
+    assert len(n_head.get_slot('sur').incoming) == 3
+
+    assert len(n_a.get_slot('sub').incoming) == 0
+    assert len(n_b.get_slot('sub').incoming) == 0
+    assert len(n_c.get_slot('sub').incoming) == 0
+
+
 def test_node_netapi_import_actors(fixed_nodenet):
     # test importing data targets as actors
     net, netapi, source = prepare(fixed_nodenet)


### PR DESCRIPTION
Introducing unlink_direction to easily remove incoming and outgoing links of a certain type from a node
