### PR TITLE
enforces explicit call of pip3 else user's default pip is used which can...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 venv: pip requirements.txt
 	test -d bin || virtualenv ./ --python=python3
-	. bin/activate; pip install -Ur requirements.txt
+	. bin/activate; pip3 install -Ur requirements.txt
 	touch bin/activate
 
 pip:


### PR DESCRIPTION
... cause trouble. 

On the long run we need a generic solution which works for users who do not use homebrew #imo.
