### PR TITLE
Unify runners

### DIFF
--- a/micropsi_core/_runtime_api_world.py
+++ b/micropsi_core/_runtime_api_world.py
@@ -149,54 +149,6 @@ def set_world_properties(world_uid, world_name=None, owner=None):
     return True
 
 
-# def start_worldrunner(world_uid):
-#     """Starts a thread that regularly advances the world simulation."""
-#     micropsi_core.runtime.worlds[world_uid].is_active = True
-#     if micropsi_core.runtime.runner['world']['runner'].paused:
-#         micropsi_core.runtime.runner['world']['runner'].resume()
-#     return True
-
-
-# def get_worldrunner_timestep():
-#     """Returns the speed that has been configured for the world runner (in ms)."""
-#     return micropsi_core.runtime.configs['worldrunner_timestep']
-
-
-# def get_is_world_running(world_uid):
-#     """Returns True if an worldrunner is active for the given world, False otherwise."""
-#     return micropsi_core.runtime.worlds[world_uid].is_active
-
-
-# def set_worldrunner_timestep(timestep):
-#     """Sets the interval of the simulation steps for the world runner (in ms)."""
-#     micropsi_core.runtime.configs['worldrunner_timestep'] = timestep
-#     return True
-
-
-# def stop_worldrunner(world_uid):
-#     """Ends the thread of the continuous world simulation."""
-#     micropsi_core.runtime.worlds[world_uid].is_active = False
-#     test = {micropsi_core.runtime.worlds[uid].is_active for uid in micropsi_core.runtime.worlds}
-#     if True not in test:
-#         micropsi_core.runtime.runner['world']['runner'].pause()
-
-#     return True
-
-
-# def step_world(world_uid, return_world_view=False):
-#     """Advances the world simulation by one step.
-
-#     Arguments:
-#         world_uid: the uid of the simulation world
-#         return_world_view: if True, return the current world state for UI purposes
-#     """
-
-#     micropsi_core.runtime.worlds[world_uid].step()
-#     if return_world_view:
-#         return get_world_view(world_uid)
-#     return micropsi_core.runtime.worlds[world_uid].current_step
-
-
 def revert_world(world_uid):
     """Reverts the world to the last saved state."""
     data = micropsi_core.runtime.world_data[world_uid]

--- a/micropsi_core/_runtime_api_world.py
+++ b/micropsi_core/_runtime_api_world.py
@@ -131,9 +131,9 @@ def get_world_view(world_uid, step):
     """Returns the current state of the world for UI purposes, if current step is newer than the supplied one."""
     if world_uid not in micropsi_core.runtime.worlds:
         raise KeyError("World not found")
-    if world_uid in micropsi_core.runtime.WorldRunner.last_exception:
-        e = micropsi_core.runtime.WorldRunner.last_exception[world_uid]
-        del micropsi_core.runtime.WorldRunner.last_exception[world_uid]
+    if world_uid in micropsi_core.runtime.MicropsiRunner.last_world_exception:
+        e = micropsi_core.runtime.MicropsiRunner.last_world_exception[world_uid]
+        del micropsi_core.runtime.MicropsiRunner.last_world_exception[world_uid]
         raise Exception("Error while stepping world").with_traceback(e[2]) from e[1]
     if step <= micropsi_core.runtime.worlds[world_uid].current_step:
         return micropsi_core.runtime.worlds[world_uid].get_world_view(step)

--- a/micropsi_core/_runtime_api_world.py
+++ b/micropsi_core/_runtime_api_world.py
@@ -149,52 +149,52 @@ def set_world_properties(world_uid, world_name=None, owner=None):
     return True
 
 
-def start_worldrunner(world_uid):
-    """Starts a thread that regularly advances the world simulation."""
-    micropsi_core.runtime.worlds[world_uid].is_active = True
-    if micropsi_core.runtime.runner['world']['runner'].paused:
-        micropsi_core.runtime.runner['world']['runner'].resume()
-    return True
+# def start_worldrunner(world_uid):
+#     """Starts a thread that regularly advances the world simulation."""
+#     micropsi_core.runtime.worlds[world_uid].is_active = True
+#     if micropsi_core.runtime.runner['world']['runner'].paused:
+#         micropsi_core.runtime.runner['world']['runner'].resume()
+#     return True
 
 
-def get_worldrunner_timestep():
-    """Returns the speed that has been configured for the world runner (in ms)."""
-    return micropsi_core.runtime.configs['worldrunner_timestep']
+# def get_worldrunner_timestep():
+#     """Returns the speed that has been configured for the world runner (in ms)."""
+#     return micropsi_core.runtime.configs['worldrunner_timestep']
 
 
-def get_is_world_running(world_uid):
-    """Returns True if an worldrunner is active for the given world, False otherwise."""
-    return micropsi_core.runtime.worlds[world_uid].is_active
+# def get_is_world_running(world_uid):
+#     """Returns True if an worldrunner is active for the given world, False otherwise."""
+#     return micropsi_core.runtime.worlds[world_uid].is_active
 
 
-def set_worldrunner_timestep(timestep):
-    """Sets the interval of the simulation steps for the world runner (in ms)."""
-    micropsi_core.runtime.configs['worldrunner_timestep'] = timestep
-    return True
+# def set_worldrunner_timestep(timestep):
+#     """Sets the interval of the simulation steps for the world runner (in ms)."""
+#     micropsi_core.runtime.configs['worldrunner_timestep'] = timestep
+#     return True
 
 
-def stop_worldrunner(world_uid):
-    """Ends the thread of the continuous world simulation."""
-    micropsi_core.runtime.worlds[world_uid].is_active = False
-    test = {micropsi_core.runtime.worlds[uid].is_active for uid in micropsi_core.runtime.worlds}
-    if True not in test:
-        micropsi_core.runtime.runner['world']['runner'].pause()
+# def stop_worldrunner(world_uid):
+#     """Ends the thread of the continuous world simulation."""
+#     micropsi_core.runtime.worlds[world_uid].is_active = False
+#     test = {micropsi_core.runtime.worlds[uid].is_active for uid in micropsi_core.runtime.worlds}
+#     if True not in test:
+#         micropsi_core.runtime.runner['world']['runner'].pause()
 
-    return True
+#     return True
 
 
-def step_world(world_uid, return_world_view=False):
-    """Advances the world simulation by one step.
+# def step_world(world_uid, return_world_view=False):
+#     """Advances the world simulation by one step.
 
-    Arguments:
-        world_uid: the uid of the simulation world
-        return_world_view: if True, return the current world state for UI purposes
-    """
+#     Arguments:
+#         world_uid: the uid of the simulation world
+#         return_world_view: if True, return the current world state for UI purposes
+#     """
 
-    micropsi_core.runtime.worlds[world_uid].step()
-    if return_world_view:
-        return get_world_view(world_uid)
-    return micropsi_core.runtime.worlds[world_uid].current_step
+#     micropsi_core.runtime.worlds[world_uid].step()
+#     if return_world_view:
+#         return get_world_view(world_uid)
+#     return micropsi_core.runtime.worlds[world_uid].current_step
 
 
 def revert_world(world_uid):

--- a/micropsi_core/nodenet/nodenet.py
+++ b/micropsi_core/nodenet/nodenet.py
@@ -378,7 +378,7 @@ class Nodenet(metaclass=ABCMeta):
 
     def update_monitors(self):
         for uid in self.__monitors:
-            self.__monitors[uid].step(self.step)
+            self.__monitors[uid].step(self.current_step)
 
     def construct_monitors_dict(self):
         data = {}

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -83,7 +83,6 @@ class MicropsiRunner(threading.Thread):
         self.paused = True
         self.state = threading.Condition()
         self.start()
-        self.ticks = 0
 
     def run(self):
         while runner['running']:
@@ -102,24 +101,19 @@ class MicropsiRunner(threading.Thread):
                 if nodenets[uid].is_active:
                     log = True
                     try:
-                        print('step nodenet')
                         nodenets[uid].step()
                         nodenets[uid].update_monitors()
                     except:
                         nodenets[uid].is_active = False
                         logging.getLogger("nodenet").error("Exception in NodenetRunner:", exc_info=1)
                         MicropsiRunner.last_nodenet_exception[uid] = sys.exc_info()
-
-                    if nodenets[uid].world and self.ticks % runner['factor'] == 0:
+                    if nodenets[uid].world and nodenets[uid].current_step % runner['factor'] == 0:
                         try:
-                            print('step world')
                             nodenets[uid].world.step()
                         except:
                             nodenets[uid].world.is_active = False
                             logging.getLogger("world").error("Exception in WorldRunner:", exc_info=1)
                             MicropsiRunner.last_world_exception[nodenets[uid].world.uid] = sys.exc_info()
-
-            self.ticks += 1
 
             elapsed = datetime.now() - start
             if log:
@@ -447,6 +441,8 @@ def step_nodenet(nodenet_uid):
     """
     nodenets[nodenet_uid].step()
     nodenets[nodenet_uid].update_monitors()
+    if nodenets[nodenet_uid].world and nodenets[nodenet_uid].current_step % configs['runner_factor'] == 0:
+        nodenets[nodenet_uid].world.step()
     return nodenets[nodenet_uid].current_step
 
 

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -262,12 +262,12 @@ def load_nodenet(nodenet_uid):
     return False, "Nodenet %s not found in %s" % (nodenet_uid, RESOURCE_PATH)
 
 
-def get_nodenet_data(nodenet_uid, **coordinates):
+def get_nodenet_data(nodenet_uid, nodespace, coordinates):
     """ returns the current state of the nodenet """
     nodenet = get_nodenet(nodenet_uid)
     with nodenet.netlock:
         data = nodenet.data
-    data.update(get_nodenet_area(nodenet_uid, **coordinates))
+    data.update(get_nodenet_area(nodenet_uid, nodespace, **coordinates))
     data.update({
         'nodetypes': nodetypes,
         'native_modules': native_modules
@@ -657,7 +657,7 @@ def get_nodespace_list(nodenet_uid):
     return data
 
 
-def get_nodespace(nodenet_uid, nodespace, step, **coordinates):
+def get_nodespace(nodenet_uid, nodespace, step=0, coordinates={}):
     """Returns the current state of the nodespace for UI purposes, if current step is newer than supplied one."""
     data = {}
     if nodenet_uid in MicropsiRunner.last_nodenet_exception:

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -111,7 +111,7 @@ class MicropsiRunner(threading.Thread):
                         try:
                             nodenets[uid].world.step()
                         except:
-                            nodenets[uid].world.is_active = False
+                            nodenets[uid].is_active = False
                             logging.getLogger("world").error("Exception in WorldRunner:", exc_info=1)
                             MicropsiRunner.last_world_exception[nodenets[uid].world.uid] = sys.exc_info()
 

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -167,9 +167,18 @@ def set_logging_levels(system=None, world=None, nodenet=None):
 
 
 def get_logger_messages(loggers=[], after=0):
+    """ Returns messages for the specified loggers.
+        If given, limits the messages to those that occured after the given timestamp"""
     if not isinstance(loggers, list):
         loggers = [loggers]
     return logger.get_logs(loggers, after)
+
+
+def get_monitoring_info(nodenet_uid, logger=[], after=0):
+    """ Returns log-messages and monitor-data for the given nodenet."""
+    data = get_monitor_data(nodenet_uid, 0)
+    data['logs'] = get_logger_messages(logger, after)
+    return data
 
 
 def get_logging_levels():

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -725,6 +725,18 @@ def new_nodenet(name, owner=None, engine='dict_engine', template=None, worldadap
         uid=uid)
 
 
+@rpc("get_current_state")
+def get_current_state(nodenet=None, world=None, monitors=None, **_):
+    data = {}
+    if nodenet is not None:
+        data['nodenet'] = runtime.get_nodespace(**nodenet)
+    if world is not None:
+        data['world'] = runtime.get_world_view(**world)
+    if monitors is not None:
+        data['monitors'] = runtime.get_monitoring_info(**monitors)
+    return True, data
+
+
 @rpc("generate_uid")
 def generate_uid():
     return True, tools.generate_uid()
@@ -1140,8 +1152,7 @@ def get_logger_messages(logger=[], after=0):
 
 @rpc("get_monitoring_info")
 def get_monitoring_info(nodenet_uid, logger=[], after=0):
-    data = runtime.get_monitor_data(nodenet_uid, 0)
-    data['logs'] = runtime.get_logger_messages(logger, after)
+    data = runtime.get_monitoring_info(nodenet_uid, logger, after)
     return True, data
 
 

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -720,10 +720,10 @@ def get_current_state(nodenet_uid, nodenet=None, world=None, monitors=None):
     nodenet_obj = runtime.get_nodenet(nodenet_uid)
     data['simulation_running'] = nodenet_obj.is_active
     data['current_nodenet_step'] = nodenet_obj.current_step
-    data['current_world_step'] = nodenet_obj.world.current_step
+    data['current_world_step'] = nodenet_obj.world.current_step if nodenet_obj.world else 0
     if nodenet is not None:
         data['nodenet'] = runtime.get_nodespace(nodenet_uid=nodenet_uid, **nodenet)
-    if world is not None:
+    if world is not None and nodenet_obj.world:
         data['world'] = runtime.get_world_view(world_uid=nodenet_obj.world.uid, **world)
     if monitors is not None:
         data['monitors'] = runtime.get_monitoring_info(nodenet_uid=nodenet_uid, **monitors)

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -701,10 +701,10 @@ def select_nodenet(nodenet_uid):
 
 
 @rpc("load_nodenet")
-def load_nodenet(nodenet_uid, **coordinates):
+def load_nodenet(nodenet_uid, nodespace='Root', coordinates={}):
     result, uid = runtime.load_nodenet(nodenet_uid)
     if result:
-        data = runtime.get_nodenet_data(nodenet_uid, **coordinates)
+        data = runtime.get_nodenet_data(nodenet_uid, nodespace, coordinates)
         data['nodetypes'] = runtime.get_available_node_types(nodenet_uid)
         return True, data
     else:

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -759,8 +759,8 @@ def set_node_activation(nodenet_uid, node_uid, activation):
     return runtime.set_node_activation(nodenet_uid, node_uid, activation)
 
 
-@rpc("start_nodenetrunner", permission_required="manage nodenets")
-def start_nodenetrunner(nodenet_uid):
+@rpc("start_simulation", permission_required="manage nodenets")
+def start_simulation(nodenet_uid):
     return runtime.start_nodenetrunner(nodenet_uid)
 
 
@@ -774,18 +774,18 @@ def get_runner_properties():
     return True, runtime.get_runner_properties()
 
 
-@rpc("get_is_nodenet_running")
-def get_is_nodenet_running(nodenet_uid):
+@rpc("get_is_simulation_running")
+def get_is_simulation_running(nodenet_uid):
     return True, runtime.get_is_nodenet_running(nodenet_uid)
 
 
-@rpc("stop_nodenetrunner", permission_required="manage nodenets")
-def stop_nodenetrunner(nodenet_uid):
+@rpc("stop_simulation", permission_required="manage nodenets")
+def stop_simulation(nodenet_uid):
     return runtime.stop_nodenetrunner(nodenet_uid)
 
 
-@rpc("step_nodenet", permission_required="manage nodenets")
-def step_nodenet(nodenet_uid):
+@rpc("step_simulation", permission_required="manage nodenets")
+def step_simulation(nodenet_uid):
     return True, runtime.step_nodenet(nodenet_uid)
 
 

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -643,15 +643,15 @@ def world_list(current_world=None):
         others=dict((uid, worlds[uid]) for uid in worlds if worlds[uid].owner != user_id))
 
 
-@micropsi_app.route("/config/nodenet/runner")
-@micropsi_app.route("/config/nodenet/runner", method="POST")
-def edit_nodenetrunner():
+@micropsi_app.route("/config/runner")
+@micropsi_app.route("/config/runner", method="POST")
+def edit_runner_properties():
     user_id, permissions, token = get_request_data()
     if len(request.params) > 0:
-        runtime.set_nodenetrunner_timestep(int(request.params['runner_timestep']))
-        return dict(status="success", msg="Timestep saved")
+        runtime.set_runner_properties(int(request.params['timestep']), int(request.params['factor']))
+        return dict(status="success", msg="Settings saved")
     else:
-        return template("runner_form", mode="nodenet", action="/config/nodenet/runner", value=runtime.get_nodenetrunner_timestep())
+        return template("runner_form", action="/config/runner", value=runtime.get_runner_properties())
 
 
 @micropsi_app.route("/config/world/runner")
@@ -764,14 +764,14 @@ def start_nodenetrunner(nodenet_uid):
     return runtime.start_nodenetrunner(nodenet_uid)
 
 
-@rpc("set_nodenetrunner_timestep", permission_required="manage nodenets")
-def set_nodenetrunner_timestep(timestep):
-    return runtime.set_nodenetrunner_timestep(timestep)
+@rpc("set_runner_properties", permission_required="manage server")
+def set_runner_properties(timestep, factor):
+    return runtime.set_runner_properties(timestep, factor)
 
 
-@rpc("get_nodenetrunner_timestep", permission_required="manage server")
-def get_nodenetrunner_timestep():
-    return True, runtime.get_nodenetrunner_timestep()
+@rpc("get_runner_properties")
+def get_runner_properties():
+    return True, runtime.get_runner_properties()
 
 
 @rpc("get_is_nodenet_running")

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -654,15 +654,15 @@ def edit_runner_properties():
         return template("runner_form", action="/config/runner", value=runtime.get_runner_properties())
 
 
-@micropsi_app.route("/config/world/runner")
-@micropsi_app.route("/config/world/runner", method="POST")
-def edit_worldrunner():
-    user_id, permissions, token = get_request_data()
-    if len(request.params) > 0:
-        runtime.set_worldrunner_timestep(int(request.params['runner_timestep']))
-        return dict(status="success", msg="Timestep saved")
-    else:
-        return template("runner_form", mode="world", action="/config/world/runner", value=runtime.get_worldrunner_timestep())
+# @micropsi_app.route("/config/world/runner")
+# @micropsi_app.route("/config/world/runner", method="POST")
+# def edit_worldrunner():
+#     user_id, permissions, token = get_request_data()
+#     if len(request.params) > 0:
+#         runtime.set_worldrunner_timestep(int(request.params['runner_timestep']))
+#         return dict(status="success", msg="Timestep saved")
+#     else:
+#         return template("runner_form", mode="world", action="/config/world/runner", value=runtime.get_worldrunner_timestep())
 
 
 @micropsi_app.route("/create_new_nodenet_form")
@@ -901,34 +901,34 @@ def set_world_data(world_uid, world_name=None, owner=None):
     return runtime.set_world_properties(world_uid, world_name, owner)
 
 
-@rpc("start_worldrunner", permission_required="manage worlds")
-def start_worldrunner(world_uid):
-    return runtime.start_worldrunner(world_uid)
+# @rpc("start_worldrunner", permission_required="manage worlds")
+# def start_worldrunner(world_uid):
+#     return runtime.start_worldrunner(world_uid)
 
 
-@rpc("get_worldrunner_timestep")
-def get_worldrunner_timestep():
-    return True, runtime.get_worldrunner_timestep()
+# @rpc("get_worldrunner_timestep")
+# def get_worldrunner_timestep():
+#     return True, runtime.get_worldrunner_timestep()
 
 
-@rpc("get_is_world_running")
-def get_is_world_running(world_uid):
-    return True, runtime.get_is_world_running(world_uid)
+# @rpc("get_is_world_running")
+# def get_is_world_running(world_uid):
+#     return True, runtime.get_is_world_running(world_uid)
 
 
-@rpc("set_worldrunner_timestep", permission_required="manage server")
-def set_worldrunner_timestep(timestep):
-    return runtime.set_worldrunner_timestep(timestep)
+# @rpc("set_worldrunner_timestep", permission_required="manage server")
+# def set_worldrunner_timestep(timestep):
+#     return runtime.set_worldrunner_timestep(timestep)
 
 
-@rpc("stop_worldrunner", permission_required="manage worlds")
-def stop_worldrunner(world_uid):
-    return runtime.stop_worldrunner(world_uid)
+# @rpc("stop_worldrunner", permission_required="manage worlds")
+# def stop_worldrunner(world_uid):
+#     return runtime.stop_worldrunner(world_uid)
 
 
-@rpc("step_world", permission_required="manage worlds")
-def step_world(world_uid, return_world_view=False):
-    return True, runtime.step_world(world_uid, return_world_view)
+# @rpc("step_world", permission_required="manage worlds")
+# def step_world(world_uid, return_world_view=False):
+#     return True, runtime.step_world(world_uid, return_world_view)
 
 
 @rpc("revert_world", permission_required="manage worlds")

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -726,14 +726,18 @@ def new_nodenet(name, owner=None, engine='dict_engine', template=None, worldadap
 
 
 @rpc("get_current_state")
-def get_current_state(nodenet=None, world=None, monitors=None, **_):
+def get_current_state(nodenet_uid, nodenet=None, world=None, monitors=None):
     data = {}
+    nodenet_obj = runtime.get_nodenet(nodenet_uid)
+    data['simulation_running'] = nodenet_obj.is_active
+    data['current_nodenet_step'] = nodenet_obj.current_step
+    data['current_world_step'] = nodenet_obj.world.current_step
     if nodenet is not None:
-        data['nodenet'] = runtime.get_nodespace(**nodenet)
+        data['nodenet'] = runtime.get_nodespace(nodenet_uid=nodenet_uid, **nodenet)
     if world is not None:
-        data['world'] = runtime.get_world_view(**world)
+        data['world'] = runtime.get_world_view(world_uid=nodenet_obj.world.uid, **world)
     if monitors is not None:
-        data['monitors'] = runtime.get_monitoring_info(**monitors)
+        data['monitors'] = runtime.get_monitoring_info(nodenet_uid=nodenet_uid, **monitors)
     return True, data
 
 

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -654,17 +654,6 @@ def edit_runner_properties():
         return template("runner_form", action="/config/runner", value=runtime.get_runner_properties())
 
 
-# @micropsi_app.route("/config/world/runner")
-# @micropsi_app.route("/config/world/runner", method="POST")
-# def edit_worldrunner():
-#     user_id, permissions, token = get_request_data()
-#     if len(request.params) > 0:
-#         runtime.set_worldrunner_timestep(int(request.params['runner_timestep']))
-#         return dict(status="success", msg="Timestep saved")
-#     else:
-#         return template("runner_form", mode="world", action="/config/world/runner", value=runtime.get_worldrunner_timestep())
-
-
 @micropsi_app.route("/create_new_nodenet_form")
 def create_new_nodenet_form():
     user_id, permissions, token = get_request_data()
@@ -915,36 +904,6 @@ def get_world_view(world_uid, step):
 @rpc("set_world_properties", permission_required="manage worlds")
 def set_world_data(world_uid, world_name=None, owner=None):
     return runtime.set_world_properties(world_uid, world_name, owner)
-
-
-# @rpc("start_worldrunner", permission_required="manage worlds")
-# def start_worldrunner(world_uid):
-#     return runtime.start_worldrunner(world_uid)
-
-
-# @rpc("get_worldrunner_timestep")
-# def get_worldrunner_timestep():
-#     return True, runtime.get_worldrunner_timestep()
-
-
-# @rpc("get_is_world_running")
-# def get_is_world_running(world_uid):
-#     return True, runtime.get_is_world_running(world_uid)
-
-
-# @rpc("set_worldrunner_timestep", permission_required="manage server")
-# def set_worldrunner_timestep(timestep):
-#     return runtime.set_worldrunner_timestep(timestep)
-
-
-# @rpc("stop_worldrunner", permission_required="manage worlds")
-# def stop_worldrunner(world_uid):
-#     return runtime.stop_worldrunner(world_uid)
-
-
-# @rpc("step_world", permission_required="manage worlds")
-# def step_world(world_uid, return_world_view=False):
-#     return True, runtime.step_world(world_uid, return_world_view)
 
 
 @rpc("revert_world", permission_required="manage worlds")

--- a/micropsi_server/static/css/micropsi-styles.css
+++ b/micropsi_server/static/css/micropsi-styles.css
@@ -419,3 +419,13 @@ label input[type="radio"] {
   background-color: transparent;
 }
 
+#simulation_controls{
+  margin-right: 20px;
+}
+
+#simulation_controls .step_counters {
+  font-size: 8px;
+  line-height: 9px;
+  text-align: left;
+}
+

--- a/micropsi_server/static/island/island.js
+++ b/micropsi_server/static/island/island.js
@@ -75,7 +75,7 @@ addObjectGhost = null;
 var agentsList = $('#world_agents_list table');
 
 window.get_world_data = function(){
-    return {world_uid: currentWorld, step: currentWorldSimulationStep};
+    return {step: currentWorldSimulationStep};
 }
 window.set_world_data = function(data){
     if(data.world){

--- a/micropsi_server/static/island/island.js
+++ b/micropsi_server/static/island/island.js
@@ -74,19 +74,12 @@ addObjectGhost = null;
 
 var agentsList = $('#world_agents_list table');
 
-window.get_world_data = function(){
+function get_world_data(){
     return {step: currentWorldSimulationStep};
 }
-window.set_world_data = function(data){
-    if(data.world){
-        data = data.world;
-    }
-    if(jQuery.isEmptyObject(data)){
-        if(worldRunning){
-            setTimeout(refreshWorldView, 100);
-        }
-        return null;
-    }
+
+function set_world_data(data){
+
     worldscope.activate();
     currentWorldSimulationStep = data.current_step;
     $('#world_step').val(currentWorldSimulationStep);
@@ -651,39 +644,6 @@ function initializeControls(){
     });
 }
 
-function resetWorld(event){
-    event.preventDefault();
-    worldRunning = false;
-    api.call('revert_world', {world_uid: currentWorld}, function(){
-        setCurrentWorld(currentWorld);
-    });
-}
-
-function stepWorld(event){
-    event.preventDefault();
-    if(worldRunning){
-        stopWorldrunner(event);
-    }
-    api.call('step_world', {world_uid: currentWorld}, function(){
-        refreshWorldView();
-    });
-}
-
-function startWorldrunner(event){
-    event.preventDefault();
-    api.call('start_worldrunner', {world_uid: currentWorld}, function(){
-        worldRunning = true;
-        refreshWorldView();
-    });
-}
-
-function stopWorldrunner(event){
-    event.preventDefault();
-    worldRunning = false;
-    api.call('stop_worldrunner', {world_uid: currentWorld}, function(){
-        $('#world_step').val(currentWorldSimulationStep);
-    });
-}
 
 
 // ------------------------ side bar form stuff --------------------------------------------- //

--- a/micropsi_server/static/js/dialogs.js
+++ b/micropsi_server/static/js/dialogs.js
@@ -412,7 +412,7 @@ fetch_stepping_info = function(){
 
 $(document).on('runner_started', fetch_stepping_info);
 $(document).on('runner_stepped', fetch_stepping_info);
-$(document).on('nodenet_changed', function(new_uid){
+$(document).on('nodenet_changed', function(event, new_uid){
     currentNodenet = new_uid;
 })
 $(document).on('form_submit', function(event, data){
@@ -483,7 +483,7 @@ function resetNodenet(event){
             'revert_nodenet',
             {nodenet_uid: currentNodenet},
             function(){
-                $(document).trigger('runner_stepped');
+                $(document).trigger('load_nodenet', currentNodenet);
             }
         );
     } else {

--- a/micropsi_server/static/js/dialogs.js
+++ b/micropsi_server/static/js/dialogs.js
@@ -377,7 +377,9 @@ register_stepping_function = function(type, input, callback){
     listeners[type] = {'input': input, 'callback': callback};
 }
 fetch_stepping_info = function(){
-    params = {}
+    params = {
+        nodenet_uid: currentNodenet
+    };
     for (key in listeners){
         params[key] = listeners[key].input()
     }
@@ -387,11 +389,11 @@ fetch_stepping_info = function(){
             listeners[key].callback(data);
         }
         var end = new Date().getTime();
-        if(data.nodenet.is_active){
+        if(data.simulation_running){
             if(runner_properties.timestep - (end - start) > 0){
                 window.setTimeout(fetch_stepping_info, runner_properties.timestep - (end - start));
             } else {
-                fetch_stepping_info();
+                $(document).trigger('runner_stepped');
             }
         }
     });

--- a/micropsi_server/static/js/dialogs.js
+++ b/micropsi_server/static/js/dialogs.js
@@ -381,6 +381,7 @@ $(function(){
 register_stepping_function = function(type, input, callback){
     listeners[type] = {'input': input, 'callback': callback};
 }
+
 fetch_stepping_info = function(){
     params = {
         nodenet_uid: currentNodenet
@@ -391,7 +392,9 @@ fetch_stepping_info = function(){
     api.call('get_current_state', params, success=function(data){
         var start = new Date().getTime();
         for(key in listeners){
-            listeners[key].callback(data);
+            if(data[key]){
+                listeners[key].callback(data[key]);
+            }
         }
         $('.nodenet_step').text(data.current_nodenet_step);
         $('.world_step').text(data.current_world_step);

--- a/micropsi_server/static/js/dialogs.js
+++ b/micropsi_server/static/js/dialogs.js
@@ -356,8 +356,6 @@ $(function() {
         window.location.replace(event.target.href + '/' + currentWorld);
     });
 
-
-
 });
 
 

--- a/micropsi_server/static/js/dialogs.js
+++ b/micropsi_server/static/js/dialogs.js
@@ -367,12 +367,17 @@ updateWorldAdapterSelector = function() {
 };
 
 
-runner_properties = {};
-api.call('get_runner_properties', {}, function(data){
-    runner_properties = data;
+var listeners = {}
+var simulationRunning = false;
+var currentNodenet;
+var runner_properties = {};
+
+
+$(function(){
+    setButtonStates(false);
+    currentNodenet = $.cookie('selected_nodenet') || '';
 });
 
-listeners = {}
 register_stepping_function = function(type, input, callback){
     listeners[type] = {'input': input, 'callback': callback};
 }
@@ -388,6 +393,8 @@ fetch_stepping_info = function(){
         for(key in listeners){
             listeners[key].callback(data);
         }
+        $('.nodenet_step').text(data.current_nodenet_step);
+        $('.world_step').text(data.current_world_step);
         var end = new Date().getTime();
         if(data.simulation_running){
             if(runner_properties.timestep - (end - start) > 0){
@@ -396,10 +403,15 @@ fetch_stepping_info = function(){
                 $(document).trigger('runner_stepped');
             }
         }
+        setButtonStates(data.simulation_running);
     });
 }
+
 $(document).on('runner_started', fetch_stepping_info);
 $(document).on('runner_stepped', fetch_stepping_info);
+$(document).on('nodenet_changed', function(new_uid){
+    currentNodenet = new_uid;
+})
 $(document).on('form_submit', function(event, data){
     if(data.url == '/config/runner'){
         for(var i=0; i < data.values.length; i++){
@@ -409,6 +421,77 @@ $(document).on('form_submit', function(event, data){
             }
         }
     }
+});
+
+api.call('get_runner_properties', {}, function(data){
+    runner_properties = data;
+});
+
+function setButtonStates(running){
+    if(running){
+        $('#nodenet_start').addClass('active');
+        $('#nodenet_stop').removeClass('active');
+    } else {
+        $('#nodenet_start').removeClass('active');
+        $('#nodenet_stop').addClass('active');
+    }
+}
+
+function stepNodenet(event){
+    event.preventDefault();
+    if(simulationRunning){
+        stopNodenetrunner(event);
+    }
+    if(currentNodenet){
+        api.call("step_simulation",
+            {nodenet_uid: currentNodenet},
+            success=function(data){
+                $(document).trigger('runner_stepped');
+            });
+    } else {
+        dialogs.notification('No nodenet selected', 'error');
+    }
+}
+
+function startNodenetrunner(event){
+    event.preventDefault();
+    nodenetRunning = true;
+    if(currentNodenet){
+        api.call('start_simulation', {nodenet_uid: currentNodenet}, function(){
+            $(document).trigger('runner_started');
+        });
+    } else {
+        dialogs.notification('No nodenet selected', 'error');
+    }
+}
+function stopNodenetrunner(event){
+    event.preventDefault();
+    api.call('stop_simulation', {nodenet_uid: currentNodenet}, function(){
+        $(document).trigger('runner_stopped');
+        nodenetRunning = false;
+    });
+}
+
+function resetNodenet(event){
+    event.preventDefault();
+    nodenetRunning = false;
+    if(currentNodenet){
+        api.call(
+            'revert_nodenet',
+            {nodenet_uid: currentNodenet},
+            function(){
+                $(document).trigger('runner_stepped');
+            }
+        );
+    } else {
+        dialogs.notification('No nodenet selected', 'error');
+    }
+}
+$(function() {
+    $('#nodenet_start').on('click', startNodenetrunner);
+    $('#nodenet_stop').on('click', stopNodenetrunner);
+    $('#nodenet_reset').on('click', resetNodenet);
+    $('#nodenet_step_forward').on('click', stepNodenet);
 });
 
 // data tables

--- a/micropsi_server/static/js/monitor.js
+++ b/micropsi_server/static/js/monitor.js
@@ -91,8 +91,10 @@ $(function(){
 
     function refreshMonitors(){
         params = getPollParams();
-        params.nodenet_uid = currentNodenet;
-        api.call('get_monitoring_info', params, setData);
+        if(currentNodenet){
+            params.nodenet_uid = currentNodenet;
+            api.call('get_monitoring_info', params, setData);
+        }
     }
 
     function setMonitorData(data){

--- a/micropsi_server/static/js/monitor.js
+++ b/micropsi_server/static/js/monitor.js
@@ -79,9 +79,6 @@ $(function(){
     }
 
     function setData(data){
-        if(!data.logs){
-            data = data.monitors;
-        }
         setMonitorData(data);
         setLoggingData(data);
         currentSimulationStep = data.current_step;

--- a/micropsi_server/static/js/monitor.js
+++ b/micropsi_server/static/js/monitor.js
@@ -74,7 +74,6 @@ $(function(){
             }
         }
         return {
-            nodenet_uid: currentNodenet,
             logger: poll,
             after: last_logger_call
         }
@@ -92,7 +91,9 @@ $(function(){
     register_stepping_function('monitors', getPollParams, setData);
 
     function refreshMonitors(){
-        api.call('get_monitoring_info', getPollParams(), setData);
+        params = getPollParams();
+        params.nodenet_uid = currentNodenet;
+        api.call('get_monitoring_info', params, setData);
     }
 
     function setMonitorData(data){

--- a/micropsi_server/static/js/monitor.js
+++ b/micropsi_server/static/js/monitor.js
@@ -13,6 +13,7 @@ $(function(){
     var nodenetMonitors = {};
     var currentMonitors = [];
 
+    var currentSimulationStep = 0;
     var currentNodenet = null;
 
     var capturedLoggers = {
@@ -50,9 +51,7 @@ $(function(){
                     y2: 0
                 }
             }, function(data) {
-                nodenetMonitors = data.monitors;
-                currentMonitors = Object.keys(nodenetMonitors);
-                currentSimulationStep = data.step;
+                refreshMonitors();
             },
             function(data) {
                 if(data.status == 500){

--- a/micropsi_server/static/js/monitor.js
+++ b/micropsi_server/static/js/monitor.js
@@ -54,10 +54,12 @@ $(function(){
         if (currentNodenet = $.cookie('selected_nodenet')) {
             api.call('load_nodenet', {
                 nodenet_uid: currentNodenet,
-                x1: 0,
-                x2: 0,
-                y1: 0,
-                y2: 0
+                coordinates: {
+                    x1: 0,
+                    x2: 0,
+                    y1: 0,
+                    y2: 0
+                }
             }, function(data) {
                 nodenetMonitors = data.monitors;
                 currentMonitors = Object.keys(nodenetMonitors);

--- a/micropsi_server/static/js/nodenet.js
+++ b/micropsi_server/static/js/nodenet.js
@@ -2233,12 +2233,10 @@ function stepNodenet(event){
         stopNodenetrunner(event);
     }
     if(currentNodenet){
-        api.call("step_nodenet",
+        api.call("step_simulation",
             {nodenet_uid: currentNodenet},
             success=function(data){
-                refreshNodespace();
-                $(document).trigger('nodenetStepped');
-                dialogs.notification("Nodenet stepped", "success");
+                $(document).trigger('runner_stepped');
             });
     } else {
         dialogs.notification('No nodenet selected', 'error');
@@ -2249,8 +2247,8 @@ function startNodenetrunner(event){
     event.preventDefault();
     nodenetRunning = true;
     if(currentNodenet){
-        api.call('start_nodenetrunner', {nodenet_uid: currentNodenet}, function(){
-            refreshNodespace();
+        api.call('start_simulation', {nodenet_uid: currentNodenet}, function(){
+            $(document).trigger('runner_started');
         });
     } else {
         dialogs.notification('No nodenet selected', 'error');
@@ -2258,7 +2256,10 @@ function startNodenetrunner(event){
 }
 function stopNodenetrunner(event){
     event.preventDefault();
-    api.call('stop_nodenetrunner', {nodenet_uid: currentNodenet}, function(){ nodenetRunning = false; });
+    api.call('stop_simulation', {nodenet_uid: currentNodenet}, function(){
+        $(document).trigger('runner_stopped');
+        nodenetRunning = false;
+    });
 }
 
 function resetNodenet(event){

--- a/micropsi_server/static/js/nodenet.js
+++ b/micropsi_server/static/js/nodenet.js
@@ -312,6 +312,9 @@ function getNodespaceList(){
 // set visible nodes and links
 function setNodespaceData(data, changed){
     nodenetscope.activate();
+    if('nodenet' in data){
+        data = data.nodenet;
+    }
     if (data && !jQuery.isEmptyObject(data)){
         currentSimulationStep = data.current_step || 0;
         $('#nodenet_step').val(currentSimulationStep);
@@ -400,6 +403,22 @@ function setNodespaceData(data, changed){
     }
     updateViewSize();
 }
+
+function get_nodenet_data(){
+    return {
+        'nodenet_uid': currentNodenet,
+        'nodespace': currentNodeSpace,
+        'step': currentSimulationStep - 1,
+        'coordinates': {
+            x1: loaded_coordinates.x[0],
+            x2: loaded_coordinates.x[1],
+            y1: loaded_coordinates.y[0],
+            y2: loaded_coordinates.y[1]
+        },
+    }
+}
+
+register_stepping_function('nodenet', get_nodenet_data, setNodespaceData);
 
 function refreshNodespace(nodespace, coordinates, step, callback){
     if(!nodespace) nodespace = currentNodeSpace;

--- a/micropsi_server/static/js/nodenet.js
+++ b/micropsi_server/static/js/nodenet.js
@@ -219,10 +219,13 @@ function setCurrentNodenet(uid, nodespace){
     api.call('load_nodenet',
         {nodenet_uid: uid,
             nodespace: nodespace,
-            x1: loaded_coordinates.x[0],
-            x2: loaded_coordinates.x[1],
-            y1: loaded_coordinates.y[0],
-            y2: loaded_coordinates.y[1]},
+            coordinates: {
+                x1: loaded_coordinates.x[0],
+                x2: loaded_coordinates.x[1],
+                y1: loaded_coordinates.y[0],
+                y2: loaded_coordinates.y[1]
+            }
+        },
         function(data){
             nodenetscope.activate();
             toggleButtons(true);
@@ -419,10 +422,12 @@ function refreshNodespace(nodespace, coordinates, step, callback){
     if(step){
         params.step = step;
     }
-    params.x1 = parseInt(coordinates.x[0]);
-    params.x2 = parseInt(coordinates.x[1]);
-    params.y1 = parseInt(coordinates.y[0]);
-    params.y2 = parseInt(coordinates.y[1]);
+    params.coordinates = {
+        x1: parseInt(coordinates.x[0]),
+        x2: parseInt(coordinates.x[1]),
+        y1: parseInt(coordinates.y[0]),
+        y2: parseInt(coordinates.y[1])
+    };
     api.call('get_nodespace', params , success=function(data){
         var changed = nodespace != currentNodeSpace;
         if(changed){

--- a/micropsi_server/static/js/nodenet.js
+++ b/micropsi_server/static/js/nodenet.js
@@ -406,7 +406,6 @@ function setNodespaceData(data, changed){
 
 function get_nodenet_data(){
     return {
-        'nodenet_uid': currentNodenet,
         'nodespace': currentNodeSpace,
         'step': currentSimulationStep - 1,
         'coordinates': {

--- a/micropsi_server/static/js/nodenet.js
+++ b/micropsi_server/static/js/nodenet.js
@@ -312,9 +312,6 @@ function getNodespaceList(){
 // set visible nodes and links
 function setNodespaceData(data, changed){
     nodenetscope.activate();
-    if('nodenet' in data){
-        data = data.nodenet;
-    }
     if (data && !jQuery.isEmptyObject(data)){
         currentSimulationStep = data.current_step || 0;
         currentWorldadapter = data.worldadapter;
@@ -455,12 +452,8 @@ function refreshNodespace(nodespace, coordinates, step, callback){
             linkLayer.removeChildren();
         }
         loaded_coordinates = coordinates;
-        if(jQuery.isEmptyObject(data)){
-            if(nodenetRunning) setTimeout(refreshNodespace, 100);
-            return null;
-        } else {
-            nodenetRunning = data.is_active;
-        }
+        nodenetRunning = data.is_active;
+
         if (linkCreationStart){
             renderLinkDuringCreation(clickPoint);
         }
@@ -468,9 +461,6 @@ function refreshNodespace(nodespace, coordinates, step, callback){
 
         if(callback){
             callback(data);
-        }
-        if(nodenetRunning){
-            refreshNodespace();
         }
     });
 }

--- a/micropsi_server/static/js/nodenet.js
+++ b/micropsi_server/static/js/nodenet.js
@@ -153,6 +153,7 @@ function refreshNodenetList(){
             event.preventDefault();
             var el = $(event.target);
             var uid = el.attr('data');
+            $(document).trigger('nodenet_changed', uid);
             setCurrentNodenet(uid);
         });
     });
@@ -245,7 +246,6 @@ function setCurrentNodenet(uid, nodespace){
             }
 
             showDefaultForm();
-            $('#nodenet_step').val(data.current_step);
             currentNodeSpace = data['nodespace'];
             currentNodenet = uid;
 
@@ -317,7 +317,6 @@ function setNodespaceData(data, changed){
     }
     if (data && !jQuery.isEmptyObject(data)){
         currentSimulationStep = data.current_step || 0;
-        $('#nodenet_step').val(currentSimulationStep);
         currentWorldadapter = data.worldadapter;
         nodenetRunning = data.is_active;
 
@@ -2159,10 +2158,6 @@ function initializeMenus() {
 }
 
 function initializeControls(){
-    $('#nodenet_start').on('click', startNodenetrunner);
-    $('#nodenet_stop').on('click', stopNodenetrunner);
-    $('#nodenet_reset').on('click', resetNodenet);
-    $('#nodenet_step_forward').on('click', stepNodenet);
     $('#zoomOut').on('click', zoomOut);
     $('#zoomIn').on('click', zoomIn);
     $('#nodespace_control').on('click', ['data-nodespace'] ,function(event){
@@ -2248,57 +2243,6 @@ function initializeDialogs(){
         handlePasteNodes(form.serializeArray()[0].value);
         $('#paste_mode_selection_modal').modal('hide');
     });
-}
-
-function stepNodenet(event){
-    event.preventDefault();
-    if(nodenetRunning){
-        stopNodenetrunner(event);
-    }
-    if(currentNodenet){
-        api.call("step_simulation",
-            {nodenet_uid: currentNodenet},
-            success=function(data){
-                $(document).trigger('runner_stepped');
-            });
-    } else {
-        dialogs.notification('No nodenet selected', 'error');
-    }
-}
-
-function startNodenetrunner(event){
-    event.preventDefault();
-    nodenetRunning = true;
-    if(currentNodenet){
-        api.call('start_simulation', {nodenet_uid: currentNodenet}, function(){
-            $(document).trigger('runner_started');
-        });
-    } else {
-        dialogs.notification('No nodenet selected', 'error');
-    }
-}
-function stopNodenetrunner(event){
-    event.preventDefault();
-    api.call('stop_simulation', {nodenet_uid: currentNodenet}, function(){
-        $(document).trigger('runner_stopped');
-        nodenetRunning = false;
-    });
-}
-
-function resetNodenet(event){
-    event.preventDefault();
-    nodenetRunning = false;
-    if(currentNodenet){
-        api.call(
-            'revert_nodenet',
-            {nodenet_uid: currentNodenet},
-            function(){
-                setCurrentNodenet(currentNodenet);
-            }
-        );
-    } else {
-        dialogs.notification('No nodenet selected', 'error');
-    }
 }
 
 var clickPosition = null;

--- a/micropsi_server/static/js/nodenet.js
+++ b/micropsi_server/static/js/nodenet.js
@@ -140,6 +140,14 @@ refreshNodenetList();
 
 registerResizeHandler();
 
+$(document).on('load_nodenet', function(event, uid){
+    ns = 'Root';
+    if(uid == currentNodenet){
+        ns = currentNodeSpace;
+    }
+    setCurrentNodenet(uid, ns);
+});
+
 function toggleButtons(on){
     if(on)
         $('[data-nodenet-control]').removeAttr('disabled');

--- a/micropsi_server/static/js/world.js
+++ b/micropsi_server/static/js/world.js
@@ -21,7 +21,7 @@ $(window).focus(function() {
 });
 
 function get_world_data(){
-    return {world_uid: currentWorld, step: currentWorldSimulationStep};
+    return {step: currentWorldSimulationStep};
 }
 
 function set_world_data(data){

--- a/micropsi_server/static/js/world.js
+++ b/micropsi_server/static/js/world.js
@@ -7,8 +7,6 @@ currentWorldSimulationStep = 0;
 worldRunning = false;
 wasRunning = false;
 
-// initialize_world_controls();
-
 registerResizeHandler();
 
 $(window).focus(function() {
@@ -22,22 +20,26 @@ $(window).focus(function() {
     worldRunning = false;
 });
 
+function get_world_data(){
+    return {world_uid: currentWorld, step: currentWorldSimulationStep};
+}
+
+function set_world_data(data){
+    data = data.world
+    if(!jQuery.isEmptyObject(data)){
+        currentWorldSimulationStep = data.current_step;
+        $('#world_step').val(currentWorldSimulationStep);
+    }
+}
+
+register_stepping_function('world', get_world_data, set_world_data);
+
 refreshWorldView = function(){
-    api.call('get_world_view',
-        {world_uid: currentWorld, step: currentWorldSimulationStep},
-        function(data){
-            if(jQuery.isEmptyObject(data)){
-                if(worldRunning){
-                    setTimeout(refreshWorldView, 100);
-                }
-                return null;
-            }
-            currentWorldSimulationStep = data.current_step;
-            $('#world_step').val(currentWorldSimulationStep);
-            if(worldRunning){
-                refreshWorldView();
-            }
-        }, error=function(data, outcome, type){
+    api.call('get_world_view', {
+        world_uid: currentWorld,
+        step: currentWorldSimulationStep},
+        success=set_world_data,
+        error=function(data, outcome, type){
             $.cookie('selected_world', '', {expires:-1, path:'/'});
             worldRunning = false;
             api.defaultErrorCallback(data, outcome, type)

--- a/micropsi_server/static/js/world.js
+++ b/micropsi_server/static/js/world.js
@@ -7,7 +7,7 @@ currentWorldSimulationStep = 0;
 worldRunning = false;
 wasRunning = false;
 
-initialize_world_controls();
+// initialize_world_controls();
 
 registerResizeHandler();
 
@@ -47,50 +47,6 @@ refreshWorldView = function(){
 
 function updateViewSize() {
     view.draw(true);
-}
-
-function initialize_world_controls(){
-    $('#world_reset').on('click', resetWorld);
-    $('#world_step_forward').on('click', stepWorld);
-    $('#world_start').on('click', startWorldrunner);
-    $('#world_stop').on('click', stopWorldrunner);
-}
-
-
-function resetWorld(event){
-    event.preventDefault();
-    worldRunning = false;
-    api.call('revert_world', {world_uid: currentWorld}, function(){
-        window.location.reload();
-    });
-}
-
-function stepWorld(event){
-    event.preventDefault();
-    if(worldRunning){
-        stopWorldrunner(event);
-    }
-    api.call('step_world', {world_uid: currentWorld}, function(data){
-        currentWorldSimulationStep = data;
-        $('#world_step').val(currentWorldSimulationStep);
-        if(refreshWorldView) refreshWorldView();
-    });
-}
-
-function startWorldrunner(event){
-    event.preventDefault();
-    api.call('start_worldrunner', {world_uid: currentWorld}, function(){
-        worldRunning = true;
-        if(refreshWorldView) refreshWorldView();
-    });
-}
-
-function stopWorldrunner(event){
-    event.preventDefault();
-    worldRunning = false;
-    api.call('stop_worldrunner', {world_uid: currentWorld}, function(){
-        $('#world_step').val(currentWorldSimulationStep);
-    });
 }
 
 function registerResizeHandler(){

--- a/micropsi_server/static/js/world.js
+++ b/micropsi_server/static/js/world.js
@@ -9,43 +9,17 @@ wasRunning = false;
 
 registerResizeHandler();
 
-$(window).focus(function() {
-    worldRunning = wasRunning;
-    if(wasRunning){
-        if(refreshWorldView) refreshWorldView();
-    }
-})
-.blur(function() {
-    wasRunning = worldRunning;
-    worldRunning = false;
-});
-
 function get_world_data(){
     return {step: currentWorldSimulationStep};
 }
 
 function set_world_data(data){
-    data = data.world
     if(!jQuery.isEmptyObject(data)){
         currentWorldSimulationStep = data.current_step;
-        $('#world_step').val(currentWorldSimulationStep);
     }
 }
 
 register_stepping_function('world', get_world_data, set_world_data);
-
-refreshWorldView = function(){
-    api.call('get_world_view', {
-        world_uid: currentWorld,
-        step: currentWorldSimulationStep},
-        success=set_world_data,
-        error=function(data, outcome, type){
-            $.cookie('selected_world', '', {expires:-1, path:'/'});
-            worldRunning = false;
-            api.defaultErrorCallback(data, outcome, type)
-        }
-    );
-}
 
 function updateViewSize() {
     view.draw(true);

--- a/micropsi_server/static/minecraft/minecraft.js
+++ b/micropsi_server/static/minecraft/minecraft.js
@@ -27,19 +27,11 @@ if (currentWorld) {
 
 worldRunning = false;
 
-window.get_world_data = function(){
+function get_world_data(){
     return {step: currentWorldSimulationStep};
 }
-window.set_world_data = function(data){
-    data = data.world;
-    if (jQuery.isEmptyObject(data)) {
-        if (worldRunning) {
-            setTimeout(refreshWorldView, 100);
-        }
-        return null;
-    }
+function set_world_data(data){
     currentWorldSimulationStep = data.current_step;
-    $('#world_step').val(currentWorldSimulationStep);
     for (var key in data.agents) {
         if (data.agents[key].minecraft_vision_pixel) {
 

--- a/micropsi_server/static/minecraft/minecraft.js
+++ b/micropsi_server/static/minecraft/minecraft.js
@@ -28,7 +28,7 @@ if (currentWorld) {
 worldRunning = false;
 
 window.get_world_data = function(){
-    return {world_uid: currentWorld, step: currentWorldSimulationStep};
+    return {step: currentWorldSimulationStep};
 }
 window.set_world_data = function(data){
     data = data.world;

--- a/micropsi_server/static/minecraft/minecraft.js
+++ b/micropsi_server/static/minecraft/minecraft.js
@@ -27,62 +27,71 @@ if (currentWorld) {
 
 worldRunning = false;
 
+window.get_world_data = function(){
+    return {world_uid: currentWorld, step: currentWorldSimulationStep};
+}
+window.set_world_data = function(data){
+    data = data.world;
+    if (jQuery.isEmptyObject(data)) {
+        if (worldRunning) {
+            setTimeout(refreshWorldView, 100);
+        }
+        return null;
+    }
+    currentWorldSimulationStep = data.current_step;
+    $('#world_step').val(currentWorldSimulationStep);
+    for (var key in data.agents) {
+        if (data.agents[key].minecraft_vision_pixel) {
+
+            if (current_layer == 1) {
+                console.log("activating second layer ...");
+                secondLayer.activate();
+            }
+            else{
+                console.log("activating first layer ...");
+                firstLayer.activate();
+            }
+
+            var minecraft_pixel = data.agents[key].minecraft_vision_pixel;
+            for (var x = 0; x < WIDTH; x++) {
+                for (var y = 0; y < HEIGHT; y++) {
+
+                    var raster = new Raster('mc_block_img_' + minecraft_pixel[(y + x * HEIGHT) * 2]);
+                    raster.position = new Point(world.width / WIDTH * x, world.height / HEIGHT * y);
+                    var distance = minecraft_pixel[(y + x * HEIGHT) * 2 + 1];
+                    raster.scale((world.width / WIDTH) / 64 * (1 / Math.pow(distance, 1 / 5)), (world.height / HEIGHT) / 64 * (1 / Math.pow(distance, 1 / 5)));
+                }
+            }
+            if (current_layer == 1) {
+                console.log("removing frist layer children ...");
+                firstLayer.removeChildren();
+                current_layer = 0;
+            }
+            else{
+                console.log("removing frist layer children ...");
+                secondLayer.removeChildren();
+                current_layer = 1;
+            }
+            break;
+        }
+    }
+
+    updateViewSize();
+    if (worldRunning) {
+        refreshWorldView();
+    }
+}
+
+register_stepping_function('world', get_world_data, set_world_data);
+
+
 refreshWorldView = function () {
     worldscope.activate();
-    api.call('get_world_view', {
-            world_uid: currentWorld,
-            step: currentWorldSimulationStep
-    },
-        function (data) {
-            if (jQuery.isEmptyObject(data)) {
-                if (worldRunning) {
-                    setTimeout(refreshWorldView, 100);
-                }
-                return null;
-            }
-            currentWorldSimulationStep = data.current_step;
-            $('#world_step').val(currentWorldSimulationStep);
-            for (var key in data.agents) {
-                if (data.agents[key].minecraft_vision_pixel) {
-
-                    if (current_layer == 1) {
-                        console.log("activating second layer ...");
-                        secondLayer.activate();
-                    }
-                    else{
-                        console.log("activating first layer ...");
-                        firstLayer.activate();
-                    }
-
-                    var minecraft_pixel = data.agents[key].minecraft_vision_pixel;
-                    for (var x = 0; x < WIDTH; x++) {
-                        for (var y = 0; y < HEIGHT; y++) {
-
-                            var raster = new Raster('mc_block_img_' + minecraft_pixel[(y + x * HEIGHT) * 2]);
-                            raster.position = new Point(world.width / WIDTH * x, world.height / HEIGHT * y);
-                            var distance = minecraft_pixel[(y + x * HEIGHT) * 2 + 1];
-                            raster.scale((world.width / WIDTH) / 64 * (1 / Math.pow(distance, 1 / 5)), (world.height / HEIGHT) / 64 * (1 / Math.pow(distance, 1 / 5)));
-                        }
-                    }
-                    if (current_layer == 1) {
-                        console.log("removing frist layer children ...");
-                        firstLayer.removeChildren();
-                        current_layer = 0;
-                    }
-                    else{
-                        console.log("removing frist layer children ...");
-                        secondLayer.removeChildren();
-                        current_layer = 1;
-                    }
-                    break;
-                }
-            }
-
-            updateViewSize();
-            if (worldRunning) {
-                refreshWorldView();
-            }
-        }, error = function (data, outcome, type) {
+    api.call(
+        'get_world_view',
+        {world_uid: currentWorld, step: currentWorldSimulationStep},
+        success=set_world_data,
+        error=function (data, outcome, type) {
             $.cookie('selected_world', '', {
                 expires: -1,
                 path: '/'
@@ -91,9 +100,6 @@ refreshWorldView = function () {
             api.defaultErrorCallback(data, outcome, type)
         }
     );
-
-
-
 }
 
 function addAgent(worldobject) {

--- a/micropsi_server/static/minecraft/minecraft2d.js
+++ b/micropsi_server/static/minecraft/minecraft2d.js
@@ -22,7 +22,7 @@ if (currentWorld) {
 worldRunning = false;
 
 window.get_world_data = function(){
-    return {world_uid: currentWorld, step: currentWorldSimulationStep};
+    return {step: currentWorldSimulationStep};
 }
 window.set_world_data = function(data){
     data = data.world;

--- a/micropsi_server/static/minecraft/minecraft2d.js
+++ b/micropsi_server/static/minecraft/minecraft2d.js
@@ -21,69 +21,76 @@ if (currentWorld) {
 
 worldRunning = false;
 
-refreshWorldView = function () {
+window.get_world_data = function(){
+    return {world_uid: currentWorld, step: currentWorldSimulationStep};
+}
+window.set_world_data = function(data){
+    data = data.world;
+    if (jQuery.isEmptyObject(data)) {
+        if (worldRunning) {
+            setTimeout(refreshWorldView, 100);
+        }
+        return null;
+    }
+    worldscope.activate();
+    currentWorldSimulationStep = data.current_step;
     
+    if (data.projection) {
+
+        if (current_layer == 1) {
+            console.log("activating second layer ...");
+            secondLayer.activate();
+        }
+        else {
+            console.log("activating first layer ...");
+            firstLayer.activate();
+        }
+
+        var height = data.assets.height;
+        var width = data.assets.width;
+        var num_pix = 20  // 64 for jonas' textures, 25 for gamepedia
+
+        for (var x = 0; x < width; x++) {
+            for (var y = 0; y < height; y++) {
+                var raster = new Raster('mc_block_img_' + data.projection[(y + x * height) * 2]);
+                // is there a problem if x or y are 0 !? how does js or paper.js handle this ??
+                raster.position = new Point(world.width / width * x, world.height / height * y);
+                var distance = data.projection[(y + x * height) * 2 + 1];
+                // texture images are num_pix pixels long; 1/5 is a heuristic
+                // consider defining a different distance function that allows for
+                // better distinction of small distances
+                raster.scale(
+                    (world.width / width) / num_pix * (1 / Math.pow(distance, 1/5)),
+                    (world.height / height) / num_pix * (1 / Math.pow(distance, 1/5))
+                );
+            }
+        }
+
+        if (current_layer == 1) {
+            console.log("removing frist layer children ...");
+            firstLayer.removeChildren();
+            current_layer = 0;
+        }
+        else {
+            console.log("removing frist layer children ...");
+            secondLayer.removeChildren();
+            current_layer = 1;
+        }
+        // break;
+    }
+
+    updateViewSize();
+    if (worldRunning) {
+        refreshWorldView();
+    }
+}
+
+register_stepping_function('world', get_world_data, set_world_data);
+
+refreshWorldView = function () {
     api.call('get_world_properties', 
         { world_uid: currentWorld },
-        function (data) {
-            if (jQuery.isEmptyObject(data)) {
-                if (worldRunning) {
-                    setTimeout(refreshWorldView, 100);
-                }
-                return null;
-            }
-            worldscope.activate();
-            currentWorldSimulationStep = data.current_step;
-            
-            if (data.projection) {
-
-                if (current_layer == 1) {
-                    console.log("activating second layer ...");
-                    secondLayer.activate();
-                }
-                else {
-                    console.log("activating first layer ...");
-                    firstLayer.activate();
-                }
-
-                var height = data.assets.height;
-                var width = data.assets.width;
-                var num_pix = 20  // 64 for jonas' textures, 25 for gamepedia
-
-                for (var x = 0; x < width; x++) {
-                    for (var y = 0; y < height; y++) {
-                        var raster = new Raster('mc_block_img_' + data.projection[(y + x * height) * 2]);
-                        // is there a problem if x or y are 0 !? how does js or paper.js handle this ??
-                        raster.position = new Point(world.width / width * x, world.height / height * y);
-                        var distance = data.projection[(y + x * height) * 2 + 1];
-                        // texture images are num_pix pixels long; 1/5 is a heuristic
-                        // consider defining a different distance function that allows for
-                        // better distinction of small distances
-                        raster.scale(
-                            (world.width / width) / num_pix * (1 / Math.pow(distance, 1/5)),
-                            (world.height / height) / num_pix * (1 / Math.pow(distance, 1/5))
-                        );
-                    }
-                }
-
-                if (current_layer == 1) {
-                    console.log("removing frist layer children ...");
-                    firstLayer.removeChildren();
-                    current_layer = 0;
-                }
-                else {
-                    console.log("removing frist layer children ...");
-                    secondLayer.removeChildren();
-                    current_layer = 1;
-                }
-                // break;
-            }
-
-            updateViewSize();
-            if (worldRunning) {
-                refreshWorldView();
-            }
-        }, 
+        success=set_world_data,
         error = function (data) {
             $.cookie('selected_world', '', {
                 expires: -1,

--- a/micropsi_server/static/minecraft/minecraft2d.js
+++ b/micropsi_server/static/minecraft/minecraft2d.js
@@ -21,20 +21,15 @@ if (currentWorld) {
 
 worldRunning = false;
 
-window.get_world_data = function(){
+function get_world_data(){
     return {step: currentWorldSimulationStep};
 }
-window.set_world_data = function(data){
-    data = data.world;
-    if (jQuery.isEmptyObject(data)) {
-        if (worldRunning) {
-            setTimeout(refreshWorldView, 100);
-        }
-        return null;
-    }
+
+function set_world_data(data){
+
     worldscope.activate();
     currentWorldSimulationStep = data.current_step;
-    
+
     if (data.projection) {
 
         if (current_layer == 1) {
@@ -80,9 +75,6 @@ window.set_world_data = function(data){
     }
 
     updateViewSize();
-    if (worldRunning) {
-        refreshWorldView();
-    }
 }
 
 register_stepping_function('world', get_world_data, set_world_data);

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -29,7 +29,7 @@ def test_select_nodenet(app, test_nodenet):
 
 
 def test_load_nodenet(app, test_nodenet):
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     assert_success(response)
     data = response.json_body['data']
     assert 'nodetypes' in data
@@ -46,7 +46,7 @@ def test_new_nodenet(app):
     assert_success(response)
     uid = response.json_body['data']
     assert uid is not None
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % uid)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % uid)
     assert_success(response)
     assert response.json_body['data']['name'] == 'FooBarTestNet'
     assert response.json_body['data']['nodes'] == {}
@@ -69,7 +69,7 @@ def test_set_nodenet_properties(app, test_nodenet, test_world):
     app.set_auth()
     response = app.post_json('/rpc/set_nodenet_properties', params=dict(nodenet_uid=test_nodenet, nodenet_name="new_name", worldadapter="Braitenberg", world_uid=test_world, settings={'foo': 'bar'}))
     assert_success(response)
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     data = response.json_body['data']
     assert data['name'] == 'new_name'
     assert data['worldadapter'] == 'Braitenberg'
@@ -83,7 +83,7 @@ def test_set_node_state(app, test_nodenet):
         'state': {'foo': 'bar'}
     })
     assert_success(response)
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     assert response.json_body['data']['nodes']['N1']['state'] == {'foo': 'bar'}
 
 
@@ -94,16 +94,17 @@ def test_set_node_activation(app, test_nodenet):
         'activation': '0.734'
     })
     assert_success(response)
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     sheaves = response.json_body['data']['nodes']['N1']['sheaves']
     assert sheaves['default']['activation'] == 0.734
 
 
 def test_start_simulation(app, test_nodenet):
     app.set_auth()
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     response = app.post_json('/rpc/start_simulation', params=dict(nodenet_uid=test_nodenet))
     assert_success(response)
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     assert response.json_body['data']['is_active']
 
 
@@ -147,12 +148,12 @@ def test_stop_simulation(app, test_nodenet):
 
 def test_step_simulation(app, test_nodenet):
     app.set_auth()
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     assert response.json_body['data']['current_step'] == 0
     response = app.get_json('/rpc/step_simulation(nodenet_uid="%s")' % test_nodenet)
     assert_success(response)
     assert response.json_body['data'] == 1
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     assert response.json_body['data']['current_step'] == 1
 
 
@@ -162,7 +163,7 @@ def test_revert_nodenet(app, test_nodenet, test_world):
     assert_success(response)
     response = app.get_json('/rpc/revert_nodenet(nodenet_uid="%s")' % test_nodenet)
     assert_success(response)
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     data = response.json_body['data']
     assert data['name'] == 'Testnet'
     assert data['worldadapter'] == 'Default'
@@ -177,7 +178,7 @@ def test_save_nodenet(app, test_nodenet, test_world):
     assert_success(response)
     response = app.get_json('/rpc/revert_nodenet(nodenet_uid="%s")' % test_nodenet)
     assert_success(response)
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     data = response.json_body['data']
     assert data['name'] == 'new_name'
     assert data['worldadapter'] == 'Braitenberg'
@@ -206,7 +207,7 @@ def test_import_nodenet(app, test_nodenet):
     assert_success(response)
     uid = response.json_body['data']
     assert uid is not None
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % uid)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % uid)
     assert list(response.json_body['data']['nodes'].keys()) == ['N1']
     assert response.json_body['data']['name'] == 'Testnet'
     response = app.get_json('/rpc/delete_nodenet(nodenet_uid="%s")' % uid)
@@ -229,7 +230,7 @@ def test_merge_nodenet(app, test_nodenet):
         'nodenet_data': json.dumps(data)
     })
     assert_success(response)
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % uid)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % uid)
     assert list(response.json_body['data']['nodes'].keys()) == ['N1']
     assert response.json_body['data']['name'] == 'Testnet'
     response = app.get_json('/rpc/delete_nodenet(nodenet_uid="%s")' % uid)
@@ -637,7 +638,7 @@ def test_get_nodespace(app, test_nodenet):
         'nodenet_uid': test_nodenet,
         'nodespace': 'Root',
         'step': -1,
-        'x1': 0, 'x2': 100, 'y1': 0, 'y2': 100
+        'coordinates': {'x1': 0, 'x2': 100, 'y1': 0, 'y2': 100}
     })
     assert_success(response)
     assert 'N1' in response.json_body['data']['nodes']
@@ -712,7 +713,7 @@ def test_delete_node(app, test_nodenet):
         'node_uid': 'N1'
     })
     assert_success(response)
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     assert response.json_body['data']['nodes'] == {}
 
 
@@ -1058,7 +1059,7 @@ def test_nodenet_data_structure(app, test_nodenet, nodetype_def, nodefunc_def):
     })
     monitor_uid = response.json_body['data']
 
-    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
+    response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",coordinates={"x1":0,"x2":100,"y1":0,"y2":100})' % test_nodenet)
     data = response.json_body['data']
 
     # Monitors

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -99,9 +99,9 @@ def test_set_node_activation(app, test_nodenet):
     assert sheaves['default']['activation'] == 0.734
 
 
-def test_start_nodenetrunner(app, test_nodenet):
+def test_start_simulation(app, test_nodenet):
     app.set_auth()
-    response = app.post_json('/rpc/start_nodenetrunner', params=dict(nodenet_uid=test_nodenet))
+    response = app.post_json('/rpc/start_simulation', params=dict(nodenet_uid=test_nodenet))
     assert_success(response)
     response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
     assert response.json_body['data']['is_active']
@@ -125,31 +125,31 @@ def test_set_runner_properties(app):
     assert response.json_body['data']['factor'] == 12
 
 
-def test_get_is_nodenet_running(app, test_nodenet):
-    response = app.get_json('/rpc/get_is_nodenet_running(nodenet_uid="%s")' % test_nodenet)
+def test_get_is_simulation_running(app, test_nodenet):
+    response = app.get_json('/rpc/get_is_simulation_running(nodenet_uid="%s")' % test_nodenet)
     assert_success(response)
     assert not response.json_body['data']
 
 
-def test_stop_nodenetrunner(app, test_nodenet):
+def test_stop_simulation(app, test_nodenet):
     app.set_auth()
-    response = app.post_json('/rpc/start_nodenetrunner', params=dict(nodenet_uid=test_nodenet))
+    response = app.post_json('/rpc/start_simulation', params=dict(nodenet_uid=test_nodenet))
     assert_success(response)
-    response = app.get_json('/rpc/get_is_nodenet_running(nodenet_uid="%s")' % test_nodenet)
+    response = app.get_json('/rpc/get_is_simulation_running(nodenet_uid="%s")' % test_nodenet)
     assert_success(response)
     assert response.json_body['data']
-    response = app.post_json('/rpc/stop_nodenetrunner', params=dict(nodenet_uid=test_nodenet))
+    response = app.post_json('/rpc/stop_simulation', params=dict(nodenet_uid=test_nodenet))
     assert_success(response)
-    response = app.get_json('/rpc/get_is_nodenet_running(nodenet_uid="%s")' % test_nodenet)
+    response = app.get_json('/rpc/get_is_simulation_running(nodenet_uid="%s")' % test_nodenet)
     assert_success(response)
     assert not response.json_body['data']
 
 
-def test_step_nodenet(app, test_nodenet):
+def test_step_simulation(app, test_nodenet):
     app.set_auth()
     response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)
     assert response.json_body['data']['current_step'] == 0
-    response = app.get_json('/rpc/step_nodenet(nodenet_uid="%s")' % test_nodenet)
+    response = app.get_json('/rpc/step_simulation(nodenet_uid="%s")' % test_nodenet)
     assert_success(response)
     assert response.json_body['data'] == 1
     response = app.get_json('/rpc/load_nodenet(nodenet_uid="%s",x1=0,x2=100,y1=0,y2=100)' % test_nodenet)

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -454,54 +454,6 @@ def test_set_world_properties(app, test_world):
     assert response.json_body['data']['name'] == "asdf"
 
 
-# def test_get_is_world_running(app, test_world):
-#     response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
-#     assert_success(response)
-#     assert not response.json_body['data']
-
-
-# def test_start_worldrunner(app, test_world):
-#     app.set_auth()
-#     response = app.post_json('/rpc/start_worldrunner', params=dict(world_uid=test_world))
-#     assert_success(response)
-#     response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
-#     assert response.json_body['data']
-
-
-# def test_get_worldrunner_timestep(app):
-#     response = app.get_json('/rpc/get_worldrunner_timestep()')
-#     assert_success(response)
-#     assert response.json_body['data'] is not None
-
-
-# def test_set_worldrunner_timestep(app):
-#     app.set_auth()
-#     response = app.post_json('/rpc/set_worldrunner_timestep', params=dict(timestep=10))
-#     assert_success(response)
-#     response = app.get_json('/rpc/get_worldrunner_timestep()')
-#     assert response.json_body['data'] == 10
-
-
-# def test_stop_worldrunner(app, test_world):
-#     app.set_auth()
-#     response = app.post_json('/rpc/start_worldrunner', params=dict(world_uid=test_world))
-#     response = app.post_json('/rpc/stop_worldrunner', params=dict(world_uid=test_world))
-#     assert_success(response)
-#     response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
-#     assert not response.json_body['data']
-
-
-# def test_step_world(app, test_world):
-#     app.set_auth()
-#     response = app.get_json('/rpc/get_world_view(world_uid="%s",step=0)' % test_world)
-#     step = response.json_body['data']['current_step']
-#     response = app.get_json('/rpc/step_world(world_uid="%s")' % test_world)
-#     assert_success(response)
-#     assert response.json_body['data'] == 1
-#     response = app.get_json('/rpc/get_world_view(world_uid="%s",step=0)' % test_world)
-#     assert response.json_body['data']['current_step'] == step + 1
-
-
 def test_revert_world(app, test_world):
     app.set_auth()
     response = app.post_json('/rpc/add_worldobject', params={

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -405,52 +405,52 @@ def test_set_world_properties(app, test_world):
     assert response.json_body['data']['name'] == "asdf"
 
 
-def test_get_is_world_running(app, test_world):
-    response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
-    assert_success(response)
-    assert not response.json_body['data']
+# def test_get_is_world_running(app, test_world):
+#     response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
+#     assert_success(response)
+#     assert not response.json_body['data']
 
 
-def test_start_worldrunner(app, test_world):
-    app.set_auth()
-    response = app.post_json('/rpc/start_worldrunner', params=dict(world_uid=test_world))
-    assert_success(response)
-    response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
-    assert response.json_body['data']
+# def test_start_worldrunner(app, test_world):
+#     app.set_auth()
+#     response = app.post_json('/rpc/start_worldrunner', params=dict(world_uid=test_world))
+#     assert_success(response)
+#     response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
+#     assert response.json_body['data']
 
 
-def test_get_worldrunner_timestep(app):
-    response = app.get_json('/rpc/get_worldrunner_timestep()')
-    assert_success(response)
-    assert response.json_body['data'] is not None
+# def test_get_worldrunner_timestep(app):
+#     response = app.get_json('/rpc/get_worldrunner_timestep()')
+#     assert_success(response)
+#     assert response.json_body['data'] is not None
 
 
-def test_set_worldrunner_timestep(app):
-    app.set_auth()
-    response = app.post_json('/rpc/set_worldrunner_timestep', params=dict(timestep=10))
-    assert_success(response)
-    response = app.get_json('/rpc/get_worldrunner_timestep()')
-    assert response.json_body['data'] == 10
+# def test_set_worldrunner_timestep(app):
+#     app.set_auth()
+#     response = app.post_json('/rpc/set_worldrunner_timestep', params=dict(timestep=10))
+#     assert_success(response)
+#     response = app.get_json('/rpc/get_worldrunner_timestep()')
+#     assert response.json_body['data'] == 10
 
 
-def test_stop_worldrunner(app, test_world):
-    app.set_auth()
-    response = app.post_json('/rpc/start_worldrunner', params=dict(world_uid=test_world))
-    response = app.post_json('/rpc/stop_worldrunner', params=dict(world_uid=test_world))
-    assert_success(response)
-    response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
-    assert not response.json_body['data']
+# def test_stop_worldrunner(app, test_world):
+#     app.set_auth()
+#     response = app.post_json('/rpc/start_worldrunner', params=dict(world_uid=test_world))
+#     response = app.post_json('/rpc/stop_worldrunner', params=dict(world_uid=test_world))
+#     assert_success(response)
+#     response = app.get_json('/rpc/get_is_world_running(world_uid="%s")' % test_world)
+#     assert not response.json_body['data']
 
 
-def test_step_world(app, test_world):
-    app.set_auth()
-    response = app.get_json('/rpc/get_world_view(world_uid="%s",step=0)' % test_world)
-    step = response.json_body['data']['current_step']
-    response = app.get_json('/rpc/step_world(world_uid="%s")' % test_world)
-    assert_success(response)
-    assert response.json_body['data'] == 1
-    response = app.get_json('/rpc/get_world_view(world_uid="%s",step=0)' % test_world)
-    assert response.json_body['data']['current_step'] == step + 1
+# def test_step_world(app, test_world):
+#     app.set_auth()
+#     response = app.get_json('/rpc/get_world_view(world_uid="%s",step=0)' % test_world)
+#     step = response.json_body['data']['current_step']
+#     response = app.get_json('/rpc/step_world(world_uid="%s")' % test_world)
+#     assert_success(response)
+#     assert response.json_body['data'] == 1
+#     response = app.get_json('/rpc/get_world_view(world_uid="%s",step=0)' % test_world)
+#     assert response.json_body['data']['current_step'] == step + 1
 
 
 def test_revert_world(app, test_world):
@@ -461,13 +461,11 @@ def test_revert_world(app, test_world):
         'position': [10, 10],
         'name': 'Testtree'
     })
-    response = app.get_json('/rpc/step_world(world_uid="%s")' % test_world)
     response = app.get_json('/rpc/revert_world(world_uid="%s")' % test_world)
     assert_success(response)
     response = app.get_json('/rpc/get_world_view(world_uid="%s",step=0)' % test_world)
     data = response.json_body['data']
     assert data['objects'] == {}
-    assert data['current_step'] == 0
 
 
 def test_save_world(app, test_world):
@@ -479,14 +477,12 @@ def test_save_world(app, test_world):
         'name': 'Testtree'
     })
     uid = response.json_body['data']
-    response = app.get_json('/rpc/step_world(world_uid="%s")' % test_world)
     response = app.get_json('/rpc/save_world(world_uid="%s")' % test_world)
     assert_success(response)
     response = app.get_json('/rpc/revert_world(world_uid="%s")' % test_world)
     response = app.get_json('/rpc/get_world_view(world_uid="%s",step=0)' % test_world)
     data = response.json_body['data']
     assert uid in data['objects']
-    assert data['current_step'] == 1
     # delete the world, to get the default state back
     app.get_json('/rpc/delete_world(world_uid="%s")' % test_world)
 

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -107,19 +107,22 @@ def test_start_nodenetrunner(app, test_nodenet):
     assert response.json_body['data']['is_active']
 
 
-def test_get_nodenetrunner_timestep(app):
+def test_get_runner_properties(app):
     app.set_auth()
-    response = app.get_json('/rpc/get_nodenetrunner_timestep()')
+    response = app.get_json('/rpc/get_runner_properties()')
     assert_success(response)
+    assert 'timestep' in response.json_body['data']
+    assert 'factor' in response.json_body['data']
 
 
-def test_set_nodenetrunner_timestep(app):
+def test_set_runner_properties(app):
     app.set_auth()
-    response = app.post_json('/rpc/set_nodenetrunner_timestep', params=dict(timestep=10))
+    response = app.post_json('/rpc/set_runner_properties', params=dict(timestep=123, factor=12))
     assert_success(response)
-    response = app.get_json('/rpc/get_nodenetrunner_timestep()')
+    response = app.get_json('/rpc/get_runner_properties()')
     assert_success(response)
-    assert response.json_body['data'] == 10
+    assert response.json_body['data']['timestep'] == 123
+    assert response.json_body['data']['factor'] == 12
 
 
 def test_get_is_nodenet_running(app, test_nodenet):

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -173,23 +173,25 @@ def test_get_current_state(app, test_nodenet, test_world):
     response = app.get_json('/rpc/start_simulation(nodenet_uid="%s")' % test_nodenet)
     sleep(0.2)
     response = app.post_json('/rpc/get_current_state', params={
+        'nodenet_uid': test_nodenet,
         'nodenet': {
-            'nodenet_uid': test_nodenet,
             'nodespace': 'Root',
             'step': -1,
         },
         'monitors': {
-            'nodenet_uid': test_nodenet,
             'logger': ['system', 'world', 'nodenet'],
             'after': 0
         },
         'world': {
-            'world_uid': test_world,
             'step': -1
         }
     })
 
     data = response.json_body['data']
+
+    assert data['current_nodenet_step'] > 0
+    assert data['current_world_step'] > 0
+    assert data['simulation_running']
 
     assert 'nodenet' in data
     assert data['nodenet']['current_step'] > 0

--- a/micropsi_server/view/menu.tpl
+++ b/micropsi_server/view/menu.tpl
@@ -95,6 +95,15 @@
                     %end
                 </div>
             %end
+                <div id="simulation_controls" class="btn-group pull-right">
+                    <span class="btn step_counters">
+                        World:<span class="world_step">0</span><br/>
+                        Net:<span class="nodenet_step">0</span></span>
+                  <a href="#" id="nodenet_reset" class="btn" data-nodenet-control><i class="icon-fast-backward"></i></a>
+                  <a href="#" id="nodenet_start" class="btn" data-nodenet-control><i class="icon-play"></i></a>
+                  <a href="#" id="nodenet_step_forward" class="btn" data-nodenet-control><i class="icon-step-forward"></i></a>
+                  <a href="#" id="nodenet_stop" class="btn" data-nodenet-control><i class="icon-pause"></i></a>
+                </div>
         </div>
     </div>
 </div>

--- a/micropsi_server/view/menu.tpl
+++ b/micropsi_server/view/menu.tpl
@@ -60,8 +60,7 @@
                     <a class="dropdown-toggle" data-toggle="dropdown" href="#menu_config">Config
                         <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/config/nodenet/runner" class="remote_form_dialog edit_nodenetrunner">Nodenet runner</a></li>
-                        <li><a href="/config/world/runner" class="remote_form_dialog edit_worldrunner">World runner</a></li>
+                        <li><a href="/config/runner" class="remote_form_dialog edit_runner_properties">Runner Properties</a></li>
                     </ul>
                 </li>
                 %end

--- a/micropsi_server/view/nodenet.tpl
+++ b/micropsi_server/view/nodenet.tpl
@@ -43,24 +43,6 @@
                         </tr>
                     </table>
                 </td>
-                <td>
-                    <table class="pull-right">
-                        <tr>
-                            <td style="white-space:nowrap;">
-                                <div class="btn-group">
-                                  <a href="#" id="nodenet_reset" class="btn" data-nodenet-control><i class="icon-fast-backward"></i></a>
-                                  <a href="#" id="nodenet_start" class="btn" data-nodenet-control><i class="icon-play"></i></a>
-                                  <a href="#" id="nodenet_step_forward" class="btn" data-nodenet-control><i class="icon-step-forward"></i></a>
-                                  <a href="#" id="nodenet_stop" class="btn" data-nodenet-control><i class="icon-pause"></i></a>
-                                </div>
-                            </td>
-
-                            <td align="right"><input id="nodenet_step" type="text" disabled="disabled"
-                                                     style="text-align:right; width:60px;" value="0"/></td>
-
-                        </tr>
-                    </table>
-                </td>
             </tr>
         </table>
     </form>

--- a/micropsi_server/view/runner_form.tpl
+++ b/micropsi_server/view/runner_form.tpl
@@ -5,7 +5,7 @@
 
     <div class="modal-header">
       <button type="button" class="close" data-dismiss="modal">×</button>
-      <h3>Timestep for {{mode}}runner</h3>
+      <h3>Runner Properties</h3>
     </div>
 
     <div class="modal-body">
@@ -23,13 +23,24 @@
                 %else:
                 <div class="control-group error">
                 %end
-                    <label class="control-label" for="runner_timestep">Interval in milliseconds</label>
+                    <label class="control-label" for="timestep">Interval in milliseconds</label>
                     <div class="controls">
-                        <input type="text" class="input-xlarge" maxlength="256" id="runner_timestep" name="runner_timestep" value="{{value}}" />
+                        <input type="text" class="input-xlarge" maxlength="256" id="timestep" name="timestep" value="{{value['timestep']}}" />
                         %if defined("name_error"):
                         <span class="help-inline">{{name_error}}</span>
-                        %else:
-                        <span class="help-inline">The runner will update the {{mode}} in the respective interval</span>
+                        %end
+                    </div>
+                </div>
+                %if not defined("name_error"):
+                <div class="control-group">
+                %else:
+                <div class="control-group error">
+                %end
+                    <label class="control-label" for="factor">Nodenet-steps per world step:</label>
+                    <div class="controls">
+                        <input type="text" class="input-xlarge" maxlength="256" id="factor" name="factor" value="{{value['factor']}}" />
+                        %if defined("name_error"):
+                        <span class="help-inline">{{name_error}}</span>
                         %end
                     </div>
                 </div>

--- a/micropsi_server/view/world.tpl
+++ b/micropsi_server/view/world.tpl
@@ -18,24 +18,6 @@
                         </tr>
                     </table>
                 </td>
-                <td>
-                    <table class="pull-right">
-                        <tr>
-                            <td style="white-space:nowrap;">
-                                <div class="btn-group">
-                                  <a href="#" id="world_reset" class="btn"><i class="icon-fast-backward"></i></a>
-                                  <a href="#" id="world_start" class="btn"><i class="icon-play"></i></a>
-                                  <a href="#" id="world_step_forward" class="btn"><i class="icon-step-forward"></i></a>
-                                  <a href="#" id="world_stop" class="btn"><i class="icon-pause"></i></a>
-                                </div>
-                            </td>
-
-                            <td align="right"><input id="world_step" type="text" disabled="disabled"
-                                                     style="text-align:right; width:60px;" value="0"/></td>
-
-                        </tr>
-                    </table>
-                </td>
             </tr>
         </table>
     </form>


### PR DESCRIPTION
Drop the concept of having 2 independent runners in favour of one runner, advancing both nodenet and world (if this nodenet lives in a world). interval and nodenet-world stepping factor can now be configured, and the UI offers controls over the runner on all pages (especially /monitors and /world).
Worlds without agents cannot be stepped anymore.

