### PR TITLE
New Pipes

### DIFF
--- a/micropsi_core/nodenet/dict_engine/dict_node.py
+++ b/micropsi_core/nodenet/dict_engine/dict_node.py
@@ -361,6 +361,10 @@ class DictGate(Gate):
         return self.__node
 
     @property
+    def empty(self):
+        return len(self.__outgoing) == 0
+
+    @property
     def activation(self):
         return self.sheaves['default']['activation']
 
@@ -481,6 +485,10 @@ class DictSlot(Slot):
     @property
     def node(self):
         return self.__node
+
+    @property
+    def empty(self):
+        return len(self.__incoming) == 0
 
     @property
     def activation(self):

--- a/micropsi_core/nodenet/node.py
+++ b/micropsi_core/nodenet/node.py
@@ -351,6 +351,14 @@ class Gate(metaclass=ABCMeta):
 
     @property
     @abstractmethod
+    def empty(self):
+        """
+        Returns true if the gate has no links
+        """
+        pass  # pragma: no cover
+
+    @property
+    @abstractmethod
     def activation(self):
         """
         Returns the gate's activation ('default' sheaf)
@@ -440,6 +448,14 @@ class Slot(metaclass=ABCMeta):
     def node(self):
         """
         Returns the Node object that this slot belongs to
+        """
+        pass  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def empty(self):
+        """
+        Returns true if the slot has no links
         """
         pass  # pragma: no cover
 

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -126,6 +126,7 @@ def pipe(netapi, node=None, sheaf="default", **params):
     sub *= node.get_slot("por").get_activation(sheaf) if not node.get_slot("por").empty else 1
     sub *= 0 if node.get_slot("gen").get_activation(sheaf) > 0 else 1
     if sub > 0: sub = 1
+    if sub < 0: sub = -1
 
     sur += node.get_slot("sur").get_activation(sheaf)
     if sur == 0: sur += node.get_slot("sur").get_activation("default")      # no activation in our sheaf, maybe from sensors?

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -131,7 +131,8 @@ def pipe(netapi, node=None, sheaf="default", **params):
 
     sur += node.get_slot("sur").get_activation(sheaf)
     if sur == 0: sur += node.get_slot("sur").get_activation("default")      # no activation in our sheaf, maybe from sensors?
-    sur += 0 if node.get_slot("gen").get_activation(sheaf) < 0.2 else 1     # cut off sur-reports from gen looping before the loop fades away
+    if abs(node.get_slot("gen").get_activation(sheaf)) > 0.2:               # cut off sur-reports from gen looping before the loop fades away
+        sur += 1 if node.get_slot("gen").get_activation(sheaf) > 0 else -1
     sur += node.get_slot("exp").get_activation(sheaf)
 
     if node.get_slot("ret").get_activation(sheaf) < 0:

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -133,7 +133,7 @@ def pipe(netapi, node=None, sheaf="default", **params):
     sur += node.get_slot("exp").get_activation(sheaf)
     if sur > 0 and len(node.get_slot('ret').get_links()) == 1:     # else: always propagate failure
         sur = 0
-    sur *= node.get_slot("por").get_activation(sheaf) if len(node.get_slot("por").get_links()) == 1 else 1
+    sur *= node.get_slot("por").get_activation(sheaf) if not node.get_slot("por").empty else 1
 
     if node.get_slot('por').empty and node.get_slot('ret').empty:           # both empty
         classifierelements = 0
@@ -143,7 +143,7 @@ def pipe(netapi, node=None, sheaf="default", **params):
         sur /= classifierelements if classifierelements > 1 else 1          # classifier case
 
     por += node.get_slot("sur").get_activation(sheaf)
-    por *= node.get_slot("por").get_activation(sheaf) if len(node.get_slot("por").get_links()) == 1 else 1
+    por *= node.get_slot("por").get_activation(sheaf) if not node.get_slot("por").empty else 1
     por += (0 if node.get_slot("gen").get_activation(sheaf) < 0.1 else 1) * \
            (1+node.get_slot("por").get_activation(sheaf))
     por += node.get_slot("por").get_activation(sheaf) if node.get_slot("sub").get_activation(sheaf) == 0 and node.get_slot("sur").get_activation(sheaf) == 0 else 0

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -116,10 +116,11 @@ def pipe(netapi, node=None, sheaf="default", **params):
     exp = 0.0
 
     gen += node.get_slot("gen").get_activation(sheaf)
-    if gen < 0.1: gen = 0                                                   # cut off gen loop at lower threshold
+    if abs(gen) < 0.1: gen = 0                                                   # cut off gen loop at lower threshold
     gen += node.get_slot("sur").get_activation(sheaf)
     gen += node.get_slot("exp").get_activation(sheaf)
     if gen > 1: gen = 1
+    if gen < -1: gen = -1
 
     sub += max(node.get_slot("sur").get_activation(sheaf), 0)
     sub += node.get_slot("sub").get_activation(sheaf)

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -115,13 +115,6 @@ def pipe(netapi, node=None, sheaf="default", **params):
     cat = 0.0
     exp = 0.0
 
-    neighbors = len(node.get_slot("por").get_links())
-
-    classifierelements = 0
-    if len(node.get_gate("sur").get_links()) == 1:
-        surnode = node.get_gate("sur").get_links()[0].target_node
-        classifierelements = len(surnode.get_gate("sub").get_links())
-
     gen += node.get_slot("gen").get_activation(sheaf)
     if gen < 0.1: gen = 0                                                   # cut off gen loop at lower threshold
     gen += node.get_slot("sur").get_activation(sheaf)
@@ -130,7 +123,7 @@ def pipe(netapi, node=None, sheaf="default", **params):
 
     sub += max(node.get_slot("sur").get_activation(sheaf), 0)
     sub += node.get_slot("sub").get_activation(sheaf)
-    sub *= 0 if node.get_slot("por").get_activation(sheaf) < 0 else 1
+    sub *= node.get_slot("por").get_activation(sheaf) if not node.get_slot("por").empty else 1
     sub *= 0 if node.get_slot("gen").get_activation(sheaf) > 0 else 1
     if sub > 0: sub = 1
 
@@ -138,31 +131,26 @@ def pipe(netapi, node=None, sheaf="default", **params):
     if sur == 0: sur += node.get_slot("sur").get_activation("default")      # no activation in our sheaf, maybe from sensors?
     sur += 0 if node.get_slot("gen").get_activation(sheaf) < 0.2 else 1     # cut off sur-reports from gen looping before the loop fades away
     sur += node.get_slot("exp").get_activation(sheaf)
-    if sur > 0:     # else: always propagate failure
-        sur *= 0 if node.get_slot("por").get_activation(sheaf) < 0 else 1
-        sur *= 0 if node.get_slot("ret").get_activation(sheaf) < 0 else 1
+    if sur > 0 and len(node.get_slot('ret').get_links()) == 1:     # else: always propagate failure
+        sur = 0
+    sur *= node.get_slot("por").get_activation(sheaf) if len(node.get_slot("por").get_links()) == 1 else 1
 
     if node.get_slot('por').empty and node.get_slot('ret').empty:           # both empty
+        classifierelements = 0
+        if len(node.get_gate("sur").get_links()) == 1:
+            surnode = node.get_gate("sur").get_links()[0].target_node
+            classifierelements = len(surnode.get_gate("sub").get_links())
         sur /= classifierelements if classifierelements > 1 else 1          # classifier case
-    #else:
-    #    if not node.get_slot('por').empty and not node.get_slot('ret').empty and sur < 0:
-    #        sur = 0                                                         # alternatives case
-    #
-    #    if node.get_slot("por").empty or (not node.get_slot('por').empty and not node.get_slot('ret').empty):
-    #        sur = 0
 
-    por += node.get_slot("sur").get_activation(sheaf) * \
-           (1+node.get_slot("por").get_activation(sheaf))
+    por += node.get_slot("sur").get_activation(sheaf)
+    por *= node.get_slot("por").get_activation(sheaf) if len(node.get_slot("por").get_links()) == 1 else 1
     por += (0 if node.get_slot("gen").get_activation(sheaf) < 0.1 else 1) * \
            (1+node.get_slot("por").get_activation(sheaf))
     por += node.get_slot("por").get_activation(sheaf) if node.get_slot("sub").get_activation(sheaf) == 0 and node.get_slot("sur").get_activation(sheaf) == 0 else 0
-    por += 1 if neighbors > 1 else 0
-    if por <= 0: por = -1
     if por > 0: por = 1
+    if por < 0: por = 0
 
     ret += node.get_slot("ret").get_activation(sheaf) if node.get_slot("sub").get_activation(sheaf) == 0 and node.get_slot("sur").get_activation(sheaf) == 0 else 0
-    ret += 1 if neighbors > 1 else 0
-    if ret <= 0: ret = -1
 
     cat = sub
     if cat == 0: cat += node.get_slot("cat").get_activation(sheaf)

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -131,9 +131,12 @@ def pipe(netapi, node=None, sheaf="default", **params):
     if sur == 0: sur += node.get_slot("sur").get_activation("default")      # no activation in our sheaf, maybe from sensors?
     sur += 0 if node.get_slot("gen").get_activation(sheaf) < 0.2 else 1     # cut off sur-reports from gen looping before the loop fades away
     sur += node.get_slot("exp").get_activation(sheaf)
-    if sur > 0 and len(node.get_slot('ret').get_links()) == 1:     # else: always propagate failure
+
+    if sur > 0 and node.get_slot("ret").get_activation(sheaf) < 0:
         sur = 0
-    sur *= node.get_slot("por").get_activation(sheaf) if not node.get_slot("por").empty else 1
+
+    if sur > 0 and not node.get_slot("por").empty:
+        sur *= node.get_slot("por").get_activation(sheaf)
 
     if node.get_slot('por').empty and node.get_slot('ret').empty:           # both empty
         classifierelements = 0
@@ -151,6 +154,9 @@ def pipe(netapi, node=None, sheaf="default", **params):
     if por < 0: por = 0
 
     ret += node.get_slot("ret").get_activation(sheaf) if node.get_slot("sub").get_activation(sheaf) == 0 and node.get_slot("sur").get_activation(sheaf) == 0 else 0
+    ret -= node.get_slot("sub").get_activation(sheaf)
+    if ret > 1:
+        ret = 1
 
     cat = sub
     if cat == 0: cat += node.get_slot("cat").get_activation(sheaf)

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -124,7 +124,7 @@ def pipe(netapi, node=None, sheaf="default", **params):
 
     sub += max(node.get_slot("sur").get_activation(sheaf), 0)
     sub += node.get_slot("sub").get_activation(sheaf)
-    sub *= node.get_slot("por").get_activation(sheaf) if not node.get_slot("por").empty else 1
+    sub *= max(node.get_slot("por").get_activation(sheaf), 0) if not node.get_slot("por").empty else 1
     sub *= 0 if node.get_slot("gen").get_activation(sheaf) > 0 else 1
     if sub > 0: sub = 1
     if sub < 0: sub = -1

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -117,6 +117,11 @@ def pipe(netapi, node=None, sheaf="default", **params):
 
     neighbors = len(node.get_slot("por").get_links())
 
+    classifierelements = 0
+    if len(node.get_gate("sur").get_links()) == 1:
+        surnode = node.get_gate("sur").get_links()[0].target_node
+        classifierelements = len(surnode.get_gate("sub").get_links())
+
     gen += node.get_slot("gen").get_activation(sheaf)
     if gen < 0.1: gen = 0                                                   # cut off gen loop at lower threshold
     gen += node.get_slot("sur").get_activation(sheaf)

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -132,11 +132,10 @@ def pipe(netapi, node=None, sheaf="default", **params):
     sur += 0 if node.get_slot("gen").get_activation(sheaf) < 0.2 else 1     # cut off sur-reports from gen looping before the loop fades away
     sur += node.get_slot("exp").get_activation(sheaf)
 
-    if sur > 0 and node.get_slot("ret").get_activation(sheaf) < 0:
+    if node.get_slot("ret").get_activation(sheaf) < 0:
         sur = 0
-
-    if sur > 0 and not node.get_slot("por").empty:
-        sur *= node.get_slot("por").get_activation(sheaf)
+    if node.get_slot("por").get_activation(sheaf) <= 0 and not node.get_slot("por").empty:
+        sur = 0
 
     if node.get_slot('por').empty and node.get_slot('ret').empty:           # both empty
         classifierelements = 0
@@ -151,10 +150,10 @@ def pipe(netapi, node=None, sheaf="default", **params):
            (1+node.get_slot("por").get_activation(sheaf))
     por += node.get_slot("por").get_activation(sheaf) if node.get_slot("sub").get_activation(sheaf) == 0 and node.get_slot("sur").get_activation(sheaf) == 0 else 0
     if por > 0: por = 1
-    if por < 0: por = 0
 
     ret += node.get_slot("ret").get_activation(sheaf) if node.get_slot("sub").get_activation(sheaf) == 0 and node.get_slot("sur").get_activation(sheaf) == 0 else 0
-    ret -= node.get_slot("sub").get_activation(sheaf)
+    if node.get_slot("por").get_activation(sheaf) >= 0:
+        ret -= node.get_slot("sub").get_activation(sheaf)
     if ret > 1:
         ret = 1
 

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -141,7 +141,15 @@ def pipe(netapi, node=None, sheaf="default", **params):
     if sur > 0:     # else: always propagate failure
         sur *= 0 if node.get_slot("por").get_activation(sheaf) < 0 else 1
         sur *= 0 if node.get_slot("ret").get_activation(sheaf) < 0 else 1
-    sur /= neighbors if neighbors > 1 else 1
+
+    if node.get_slot('por').empty and node.get_slot('ret').empty:           # both empty
+        sur /= classifierelements if classifierelements > 1 else 1          # classifier case
+    #else:
+    #    if not node.get_slot('por').empty and not node.get_slot('ret').empty and sur < 0:
+    #        sur = 0                                                         # alternatives case
+    #
+    #    if node.get_slot("por").empty or (not node.get_slot('por').empty and not node.get_slot('ret').empty):
+    #        sur = 0
 
     por += node.get_slot("sur").get_activation(sheaf) * \
            (1+node.get_slot("por").get_activation(sheaf))

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -142,7 +142,8 @@ def pipe(netapi, node=None, sheaf="default", **params):
         classifierelements = 0
         if len(node.get_gate("sur").get_links()) == 1:
             surnode = node.get_gate("sur").get_links()[0].target_node
-            classifierelements = len(surnode.get_gate("sub").get_links())
+            if surnode.type is "Pipe":
+                classifierelements = len(surnode.get_gate("sub").get_links())
         sur /= classifierelements if classifierelements > 1 else 1          # classifier case
 
     por += node.get_slot("sur").get_activation(sheaf)

--- a/micropsi_core/nodenet/nodenet.py
+++ b/micropsi_core/nodenet/nodenet.py
@@ -576,15 +576,6 @@ class NetAPI(object):
             self.__nodenet.create_link(source_node.uid, "sym", target_node.uid, symslot, weight, certainty)
             self.__nodenet.create_link(target_node.uid, "ref", source_node.uid, refslot, weight, certainty)
 
-    def link_full(self, nodes, linktype="porret", weight=1, certainty=1):
-        """
-        Creates two (reciprocal) links between all nodes in the node list (every node to every node),
-        valid linktypes are subsur, porret, and catexp.
-        """
-        for source in nodes:
-            for target in nodes:
-                self.link_with_reciprocal(source, target, linktype, weight, certainty)
-
     def unlink(self, source_node, source_gate=None, target_node=None, target_slot=None):
         """
         Deletes a link, or links, originating from the given node

--- a/micropsi_core/tests/test_node_netapi.py
+++ b/micropsi_core/tests/test_node_netapi.py
@@ -530,23 +530,6 @@ def test_node_netapi_link_with_reciprocal(fixed_nodenet):
     assert len(n_d.get_slot("gen").get_links()) == 2
 
 
-def test_node_netapi_link_full(fixed_nodenet):
-    # test fully reciprocal-linking groups of nodes
-    net, netapi, source = prepare(fixed_nodenet)
-    n_head = netapi.create_node("Pipe", "Root", "Head")
-    n_a = netapi.create_node("Pipe", "Root", "A")
-    n_b = netapi.create_node("Pipe", "Root", "B")
-    n_c = netapi.create_node("Pipe", "Root", "C")
-    n_d = netapi.create_node("Pipe", "Root", "D")
-
-    netapi.link_full([n_a, n_b, n_c, n_d])
-
-    assert len(n_a.get_slot('por').get_links()) == 4
-    assert len(n_b.get_slot('por').get_links()) == 4
-    assert len(n_c.get_slot('por').get_links()) == 4
-    assert len(n_d.get_slot('por').get_links()) == 4
-
-
 def test_node_netapi_unlink(fixed_nodenet):
     # test completely unlinking a node
     net, netapi, source = prepare(fixed_nodenet)
@@ -556,7 +539,10 @@ def test_node_netapi_unlink(fixed_nodenet):
     n_c = netapi.create_node("Pipe", "Root", "C")
     n_d = netapi.create_node("Pipe", "Root", "D")
 
-    netapi.link_full([n_a, n_b, n_c, n_d])
+    nodes = [n_a, n_b, n_c, n_d]
+    for source in nodes:
+        for target in nodes:
+            netapi.link_with_reciprocal(source, target, "porret")
 
     netapi.unlink(n_b)
 
@@ -575,7 +561,10 @@ def test_node_netapi_unlink_specific_link(fixed_nodenet):
     n_c = netapi.create_node("Pipe", "Root", "C")
     n_d = netapi.create_node("Pipe", "Root", "D")
 
-    netapi.link_full([n_a, n_b, n_c, n_d])
+    nodes = [n_a, n_b, n_c, n_d]
+    for source in nodes:
+        for target in nodes:
+            netapi.link_with_reciprocal(source, target, "porret")
 
     netapi.unlink(n_b, "por", n_c, "por")
 
@@ -594,7 +583,10 @@ def test_node_netapi_unlink_gate(fixed_nodenet):
     n_c = netapi.create_node("Pipe", "Root", "C")
     n_d = netapi.create_node("Pipe", "Root", "D")
 
-    netapi.link_full([n_a, n_b, n_c, n_d])
+    nodes = [n_a, n_b, n_c, n_d]
+    for source in nodes:
+        for target in nodes:
+            netapi.link_with_reciprocal(source, target, "porret")
 
     netapi.unlink(n_b, "por")
 
@@ -615,7 +607,11 @@ def test_node_netapi_unlink_direction(fixed_nodenet):
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
     netapi.link_with_reciprocal(n_head, n_c, "subsur")
-    netapi.link_full([n_a, n_b, n_c])
+
+    nodes = [n_a, n_b, n_c]
+    for source in nodes:
+        for target in nodes:
+            netapi.link_with_reciprocal(source, target, "porret")
 
     netapi.unlink_direction(n_b, "por")
 

--- a/micropsi_core/tests/test_node_pipe_logic.py
+++ b/micropsi_core/tests/test_node_pipe_logic.py
@@ -313,11 +313,13 @@ def test_node_pipe_logic_three_script(fixed_nodenet):
     netapi.link(source, "gen", n_b, "sur", -1)
     net.step()
     net.step()
+    net.step()     # extra steps because we're coming from a stable "all good state"
+    net.step()
     assert n_a.get_gate("sub").activation == 1
     assert n_a.get_gate("sur").activation == 0
     assert n_b.get_gate("sub").activation == 1
     assert n_b.get_gate("sur").activation == -1
-    assert n_c.get_gate("sub").activation == 0
+    assert n_c.get_gate("sub").activation == -1
     assert n_c.get_gate("sur").activation == 0
 
     net.step()

--- a/micropsi_core/tests/test_node_pipe_logic.py
+++ b/micropsi_core/tests/test_node_pipe_logic.py
@@ -63,7 +63,6 @@ def test_node_pipe_logic_classifier_two_off(fixed_nodenet):
     n_b = netapi.create_node("Pipe", "Root", "B")
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
-    netapi.link_full([n_a, n_b])
 
     for i in range(1, 3):
         net.step()
@@ -78,7 +77,6 @@ def test_node_pipe_logic_classifier_two_partial(fixed_nodenet):
     n_b = netapi.create_node("Pipe", "Root", "B")
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
-    netapi.link_full([n_a, n_b])
 
     netapi.link(source, "gen", n_a, "sur")
 
@@ -101,7 +99,6 @@ def test_node_pipe_logic_classifier_two_partially_failing(fixed_nodenet):
     n_b = netapi.create_node("Pipe", "Root", "B")
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
-    netapi.link_full([n_a, n_b])
 
     netapi.link(source, "gen", n_a, "sur", -1)
 
@@ -126,7 +123,6 @@ def test_node_pipe_logic_classifier_three_off(fixed_nodenet):
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
     netapi.link_with_reciprocal(n_head, n_c, "subsur")
-    netapi.link_full([n_a, n_b, n_c])
 
     for i in range(1, 3):
         net.step()
@@ -143,7 +139,6 @@ def test_node_pipe_logic_classifier_three_partial(fixed_nodenet):
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
     netapi.link_with_reciprocal(n_head, n_c, "subsur")
-    netapi.link_full([n_a, n_b, n_c])
 
     netapi.link(source, "gen", n_a, "sur")
 
@@ -174,7 +169,6 @@ def test_node_pipe_logic_classifier_three_partially_failing(fixed_nodenet):
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
     netapi.link_with_reciprocal(n_head, n_c, "subsur")
-    netapi.link_full([n_a, n_b, n_c])
 
     netapi.link(source, "gen", n_a, "sur", -1)
 
@@ -340,6 +334,7 @@ def test_node_pipe_logic_three_alternatives(fixed_nodenet):
     n_a.set_gate_parameter("sur", "threshold", 0)
     n_b.set_gate_parameter("sur", "threshold", 0)
     n_c.set_gate_parameter("sur", "threshold", 0)
+    netapi.link_full([n_a, n_b, n_c])
 
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
@@ -376,7 +371,6 @@ def test_node_pipe_logic_feature_binding(fixed_nodenet):
     element2 = netapi.create_node("Pipe", "Root", "Element2")
     netapi.link_with_reciprocal(schema, element1, "subsur")
     netapi.link_with_reciprocal(schema, element2, "subsur")
-    netapi.link_full([element1, element2])
 
     concrete_feature1 = netapi.create_node("Pipe", "Root", "ConcreteFeature1")
     concrete_feature2 = netapi.create_node("Pipe", "Root", "ConcreteFeature2")

--- a/micropsi_core/tests/test_node_pipe_logic.py
+++ b/micropsi_core/tests/test_node_pipe_logic.py
@@ -427,7 +427,7 @@ def test_node_pipe_logic_alternatives(fixed_nodenet):
 
     net.step()
     assert n_head.get_gate("gen").activation == -1
-    
+
 
 def test_node_pipe_logic_feature_binding(fixed_nodenet):
     # check if the same feature can be checked and bound twice

--- a/micropsi_core/tests/test_node_pipe_logic.py
+++ b/micropsi_core/tests/test_node_pipe_logic.py
@@ -326,44 +326,108 @@ def test_node_pipe_logic_three_script(fixed_nodenet):
     assert n_head.get_gate("gen").activation == -1
 
 
-def test_node_pipe_logic_three_alternatives(fixed_nodenet):
-    # create three alternatives, let one fail, one be undecided, one succeed
+def test_node_pipe_logic_alternatives(fixed_nodenet):
+    # create a script with alternatives, let one fail, one one succeed
     net, netapi, source = prepare(fixed_nodenet)
     n_head = netapi.create_node("Pipe", "Root", "Head")
     n_a = netapi.create_node("Pipe", "Root", "A")
     n_b = netapi.create_node("Pipe", "Root", "B")
     n_c = netapi.create_node("Pipe", "Root", "C")
-    n_a.set_gate_parameter("sur", "threshold", 0)
-    n_b.set_gate_parameter("sur", "threshold", 0)
-    n_c.set_gate_parameter("sur", "threshold", 0)
-    netapi.link_full([n_a, n_b, n_c])
-
+    n_b_a1 = netapi.create_node("Pipe", "Root", "B-A1")
+    n_b_a2 = netapi.create_node("Pipe", "Root", "B-A1")
     netapi.link_with_reciprocal(n_head, n_a, "subsur")
     netapi.link_with_reciprocal(n_head, n_b, "subsur")
     netapi.link_with_reciprocal(n_head, n_c, "subsur")
+    netapi.link_with_reciprocal(n_b, n_b_a1, "subsur")
+    netapi.link_with_reciprocal(n_b, n_b_a2, "subsur")
+    netapi.link_with_reciprocal(n_a, n_b, "porret")
+    netapi.link_with_reciprocal(n_b, n_c, "porret")
+    netapi.link_with_reciprocal(n_b_a1, n_b_a2, "porret")
+    netapi.link(n_b_a1, "por", n_b_a2, "por", -1)
     netapi.link(source, "gen", n_head, "sub")
     net.step()
     net.step()
 
-    netapi.link(source, "gen", n_a, "sur", 0)
-    netapi.link(source, "gen", n_b, "sur", 1)
-    netapi.link(source, "gen", n_c, "sur", -1)
+    # quiet, first node requesting
+    assert n_head.get_gate("gen").activation == 0
+    assert n_a.get_gate("sub").activation == 1
+    assert n_a.get_gate("sur").activation == 0
+    assert n_b.get_gate("sub").activation == 0
+    assert n_b.get_gate("sur").activation == 0
+    assert n_c.get_gate("sub").activation == 0
+    assert n_c.get_gate("sur").activation == 0
 
+    # reply: good!
+    netapi.link(source, "gen", n_a, "sur")
+    net.step()
+    assert n_a.get_gate("sub").activation == 1
+    assert n_a.get_gate("sur").activation == 0
+    assert n_b.get_gate("sub").activation == 0
+    assert n_b.get_gate("sur").activation == 0
+    assert n_c.get_gate("sub").activation == 0
+    assert n_c.get_gate("sur").activation == 0
+
+    # first alternative requesting
     net.step()
     net.step()
+    assert n_b_a1.get_gate("sub").activation == 1
+    assert n_b_a1.get_gate("sur").activation == 0
+    assert n_b_a2.get_gate("sub").activation == 0
+    assert n_b_a2.get_gate("sur").activation == 0
 
+    # reply: fail!
+    netapi.link(source, "gen", n_b_a1, "sur", -1)
+    net.step()
+    net.step()
+    assert n_b_a1.get_gate("sur").activation == 0
+    assert n_b_a1.get_gate("por").activation == -1
+
+    # second alternative requesting
+    assert n_b_a2.get_gate("sub").activation == 1
+    assert n_b_a2.get_gate("sur").activation == 0
+    assert n_b.get_gate("sur").activation == 0
+
+    # reply: succeed!
+    netapi.link(source, "gen", n_b_a2, "sur", 1)
+    net.step()
+    net.step()
+    assert n_b_a1.get_gate("sur").activation == 0
+    assert n_b_a1.get_gate("por").activation == -1
+    assert n_b_a2.get_gate("sub").activation == 1
+    assert n_b_a2.get_gate("sur").activation == 1
+
+    # third node good
+    netapi.link(source, "gen", n_c, "sur")
+    net.step()
+    net.step()
+    assert n_a.get_gate("sub").activation == 1
+    assert n_a.get_gate("sur").activation == 0
+    assert n_b.get_gate("sub").activation == 1
+    assert n_b.get_gate("sur").activation == 0
+    assert n_c.get_gate("sub").activation == 1
+    assert n_c.get_gate("sur").activation == 1
+
+    # overall script good
+    net.step()
     assert n_head.get_gate("gen").activation == 1
 
-    # now fail the good one
-    netapi.link(source, "gen", n_a, "sur", 0)
-    netapi.link(source, "gen", n_b, "sur", -1)
-    netapi.link(source, "gen", n_c, "sur", -1)
-
+    # now let the second alternative also fail
+    # whole script fails, third one muted
+    netapi.link(source, "gen", n_b_a2, "sur", -1)
     net.step()
     net.step()
+    net.step()     # extra steps because we're coming from a stable "all good state"
+    net.step()
+    assert n_a.get_gate("sub").activation == 1
+    assert n_a.get_gate("sur").activation == 0
+    assert n_b.get_gate("sub").activation == 1
+    assert n_b.get_gate("sur").activation == -1
+    assert n_c.get_gate("sub").activation == -1
+    assert n_c.get_gate("sur").activation == 0
 
-    assert n_head.get_gate("gen").activation == 0
-
+    net.step()
+    assert n_head.get_gate("gen").activation == -1
+    
 
 def test_node_pipe_logic_feature_binding(fixed_nodenet):
     # check if the same feature can be checked and bound twice

--- a/micropsi_core/tests/test_node_pipe_logic.py
+++ b/micropsi_core/tests/test_node_pipe_logic.py
@@ -468,7 +468,7 @@ def test_node_pipe_logic_search_ret(fixed_nodenet):
     sub_act, sur_act, por_act, ret_act, cat_act, exp_act = add_directional_activators(fixed_nodenet)
     netapi.link(source, "gen", ret_act, "gen")
 
-    netapi.link(source, "gen", n_b, "por")
+    netapi.link(source, "gen", n_b, "ret")
 
     net.step()
     net.step()

--- a/micropsi_core/tests/test_node_pipe_logic.py
+++ b/micropsi_core/tests/test_node_pipe_logic.py
@@ -319,7 +319,7 @@ def test_node_pipe_logic_three_script(fixed_nodenet):
     assert n_a.get_gate("sur").activation == 0
     assert n_b.get_gate("sub").activation == 1
     assert n_b.get_gate("sur").activation == -1
-    assert n_c.get_gate("sub").activation == -1
+    assert n_c.get_gate("sub").activation == 0
     assert n_c.get_gate("sur").activation == 0
 
     net.step()
@@ -422,7 +422,7 @@ def test_node_pipe_logic_alternatives(fixed_nodenet):
     assert n_a.get_gate("sur").activation == 0
     assert n_b.get_gate("sub").activation == 1
     assert n_b.get_gate("sur").activation == -1
-    assert n_c.get_gate("sub").activation == -1
+    assert n_c.get_gate("sub").activation == 0
     assert n_c.get_gate("sur").activation == 0
 
     net.step()


### PR DESCRIPTION
This changeset changes the default behavior of pipe nodes: When not por-ret-linked at all, they enable the sur-channel. In a schema with three features that can be checked in parallel, no por-ret links are required between the features.
Also, there is no idle activation any more.
Also, scripts with backtracking alternatives can now be created.

Note that "full linkage" is now meaningless. The NetAPI method to conveniently create full linkage has thus been removed.

Code creating schemas will have to be updated by removing the link_full NetAPI call.
Existing schemas will not work any more until all the full-linkage por-ret links have been removed.