### PR TITLE
change trigger logic:

### DIFF
--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -237,12 +237,13 @@ def trigger(netapi, node=None, sheaf="default", **params):
     else:
         waitfrom = node.get_state("waitfrom") or -1
 
+        timeout = node.get_parameter("timeout") or 10        # todo: use emo_resolution
+        condition = node.get_parameter("condition") or "="
+        response = node.get_parameter("response")
+        if response is None:
+            response = 1
+
         if node.get_slot('sub').activation > 0:
-            timeout = node.get_parameter("timeout") or 10        # todo: use emo_resolution
-            condition = node.get_parameter("condition") or "="
-            response = node.get_parameter("response")
-            if response is None:
-                response = 1
             currentstep = netapi.step
 
             success = (condition == "=" and node.get_slot('sur').activation == int(response)) or \

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -255,16 +255,19 @@ def trigger(netapi, node=None, sheaf="default", **params):
                 elif currentstep > waitfrom + int(timeout):
                     sur = -1
             else:                                   # perform burst
-                if node.get_slot('sur').activation:
-                    sur = node.get_slot('sur').activation
-                else:
-                    sub = 1
-                    node.set_state("waitfrom", currentstep)
+                sub = 1
+                node.set_state("waitfrom", currentstep)
+
         else:
+
             if waitfrom > 0:
                 node.set_state("waitfrom", -1)
-            if node.get_slot('sur').activation > 0:
-                sur = node.get_slot('sur').activation
+
+            if node.get_slot('sur').activation:
+                success = (condition == "=" and node.get_slot('sur').activation == int(response)) or \
+                          (condition == ">" and node.get_slot('sur').activation > int(response))
+                if success:
+                    sur = node.get_slot('sur').activation
 
     gen = sur
     node.activation = gen

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -258,6 +258,7 @@ def trigger(netapi, node=None, sheaf="default", **params):
             else:                                   # perform burst
                 sub = 1
                 node.set_state("waitfrom", currentstep)
+                sur = node.get_slot('sur').activation
 
         else:
 

--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -255,10 +255,16 @@ def trigger(netapi, node=None, sheaf="default", **params):
                 elif currentstep > waitfrom + int(timeout):
                     sur = -1
             else:                                   # perform burst
-                sub = 1
-                node.set_state("waitfrom", currentstep)
-        elif waitfrom > 0:
-            node.set_state("waitfrom", -1)
+                if node.get_slot('sur').activation:
+                    sur = node.get_slot('sur').activation
+                else:
+                    sub = 1
+                    node.set_state("waitfrom", currentstep)
+        else:
+            if waitfrom > 0:
+                node.set_state("waitfrom", -1)
+            if node.get_slot('sur').activation > 0:
+                sur = node.get_slot('sur').activation
 
     gen = sur
     node.activation = gen


### PR DESCRIPTION
To support bubbling through triggers, we needed some changes:
 * ~~If requested, a Trigger will only perform the burst if it has no activation on its sur-slot (and is thus already confirmed)~~
 * If a Trigger gets activation on its sur-slot without being requested, it will pass it on to gen/sur

This is considered a Request for Comments, and should not be merged without me adding some tests for this behaviour...

*update*: test added