### PR TITLE
Link decaying

### DIFF
--- a/micropsi_core/nodenet/dict_engine/dict_nodenet.py
+++ b/micropsi_core/nodenet/dict_engine/dict_nodenet.py
@@ -7,7 +7,7 @@ import warnings
 from micropsi_core.nodenet import monitor
 from micropsi_core.nodenet.node import Nodetype, STANDARD_NODETYPES
 from micropsi_core.nodenet.nodenet import Nodenet, NODENET_VERSION, NodenetLockException
-from .dict_stepoperators import DictPropagate, DictCalculate, DictDoernerianEmotionalModulators
+from .dict_stepoperators import DictPropagate, DictPORRETDecay, DictCalculate, DictDoernerianEmotionalModulators
 from .dict_node import DictNode
 from .dict_nodespace import DictNodespace
 
@@ -67,7 +67,7 @@ class DictNodenet(Nodenet):
 
         super(DictNodenet, self).__init__(name or os.path.basename(filename), worldadapter, world, owner, uid)
 
-        self.stepoperators = [DictPropagate(), DictCalculate(), DictDoernerianEmotionalModulators()]
+        self.stepoperators = [DictPropagate(), DictCalculate(), DictPORRETDecay(), DictDoernerianEmotionalModulators()]
         self.stepoperators.sort(key=lambda op: op.priority)
 
         self.__version = NODENET_VERSION  # used to check compatibility of the node net data

--- a/micropsi_core/nodenet/dict_engine/dict_stepoperators.py
+++ b/micropsi_core/nodenet/dict_engine/dict_stepoperators.py
@@ -113,6 +113,7 @@ class DictPORRETDecay(StepOperator):
 
         for node in left_boundaries:
             step = node
+            old_schema_node = step.get_gate('sur').get_links()[0].target_node
             if not step.get_gate('ret').get_links():
                 # delete single steps without por/ret linkage (and their subsur children)
                 nodes_to_delete = [step]
@@ -121,7 +122,6 @@ class DictPORRETDecay(StepOperator):
                     netapi.delete_node(n)
             else:
                 # create new schema nodes for fragments
-                old_schema_node = step.get_gate('sur').get_links()[0].target_node
                 new_schema_node = netapi.create_node(old_schema_node.type, archive_nodespace.uid, old_schema_node.name + ' Fragment')
                 while True:
                     netapi.unlink(old_schema_node, target_node=step)
@@ -134,6 +134,15 @@ class DictPORRETDecay(StepOperator):
                         step = step.get_gate('ret').get_links()[0].target_node
                     else:
                         break
+            if len(old_schema_node.get_gate('sub').get_links()) <= 1:
+                # schema node has 1 child or less, prune as whole
+                delete_nodes = [old_schema_node]
+                for l1 in old_schema_node.get_gate('sub').get_links():
+                    for l2 in l1.target_node.get_gate('sub').get_links():
+                        delete_nodes.append(l2.target_node)
+                    delete_nodes.append(l1.target_node)
+                for node in delete_nodes:
+                    netapi.delete_node(node)
 
 
 def gentle_sigmoid(x):

--- a/micropsi_core/nodenet/nodenet.py
+++ b/micropsi_core/nodenet/nodenet.py
@@ -209,7 +209,7 @@ class Nodenet(metaclass=ABCMeta):
     def create_node(self, nodetype, nodespace_uid, position, name="", uid=None, parameters=None, gate_parameters=None):
         """
         Creates a new node of the given node type (string), in the nodespace with the given UID, at the given
-        position.
+        position and returns the uid of the new node
         """
         pass  # pragma: no cover
 

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -766,8 +766,8 @@ def clone_nodes(nodenet_uid, node_uids, clonemode, nodespace=None, offset=[50, 5
 
     for _, n in copynodes.items():
         target_nodespace = nodespace if nodespace is not None else n.parent_nodespace
-        success, uid = add_node(nodenet_uid, n.type, (n.position[0] + offset[0], n.position[1] + offset[1]), nodespace=target_nodespace, state=n.clone_state(), uid=None, name=n.name + '_copy', parameters=n.clone_parameters().copy())
-        if success:
+        uid = nodenet.create_node(n.type, target_nodespace, (n.position[0] + offset[0], n.position[1] + offset[1]), name=n.name + '_copy', uid=None, parameters=n.clone_parameters().copy(), gate_parameters=n.get_gate_parameters())
+        if uid:
             uidmap[n.uid] = uid
             result['nodes'].append(nodenet.get_node(uid).data)
         else:

--- a/micropsi_core/tests/test_runtime_nodenet_basics.py
+++ b/micropsi_core/tests/test_runtime_nodenet_basics.py
@@ -216,6 +216,15 @@ def test_clone_nodes_to_new_nodespace(fixed_nodenet):
     assert a2_copy.parent_nodespace == 'ns1'
 
 
+def test_clone_nodes_copies_gate_params(fixed_nodenet):
+    nodenet = micropsi.get_nodenet(fixed_nodenet)
+    micropsi.set_gate_parameters(fixed_nodenet, 'A1', 'gen', {'decay': 0.1})
+    success, result = micropsi.clone_nodes(fixed_nodenet, ['A1'], 'internal')
+    assert success
+    copy = nodenet.get_node(result['nodes'][0]['uid'])
+    assert copy.get_gate_parameters()['gen']['decay'] == 0.1
+
+
 def test_modulators(fixed_nodenet):
     nodenet = micropsi.get_nodenet(fixed_nodenet)
 


### PR DESCRIPTION
To discuss: 

Currently, the garbage-collection (that removes single elements that got isolated from a por/ret chain) and the schema-fixer (that will construct an own schema out of isolated parts of the por/ret chain) are implemented in the PorRetDecay stepoperator. This is very convenient, since all the information needed for these operations is present at that moment. We might want to invest the overhead to implement both of them in their own stepoperators - this however is tricky for the schema-fixer.