### PR TITLE
Feature scripts

### DIFF
--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -982,9 +982,13 @@ def run_recipe(nodenet_uid, name, parameters):
     """ Calls the given recipe with the provided parameters, and returns the output, if any """
     from functools import partial
     netapi = nodenets[nodenet_uid].netapi
+    params = {}
+    for key in parameters:
+        if parameters[key] != '':
+            params[key] = parameters[key]
     if name in custom_recipes:
         func = custom_recipes[name]['function']
-        return True, func(netapi, **parameters)
+        return True, func(netapi, **params)
     else:
         return False, "Script not found"
 

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -967,6 +967,28 @@ def user_prompt_response(nodenet_uid, node_uid, values, resume_nodenet):
     nodenets[nodenet_uid].is_active = resume_nodenet
 
 
+def get_available_userscripts():
+    """ Returns a dict of the available user-scripts """
+    scripts = {}
+    for name, data in userscripts.items():
+        scripts[name] = {
+            'name': name,
+            'parameters': data['parameters']
+        }
+    return scripts
+
+
+def run_userscript(nodenet_uid, name, parameters):
+    """ Calls the given userscript with the provided parameters, and returns the output, if any """
+    from functools import partial
+    netapi = nodenets[nodenet_uid].netapi
+    if name in userscripts:
+        func = userscripts[name]['function']
+        return True, func(netapi, **parameters)
+    else:
+        return False, "Script not found"
+
+
 # --- end of API
 
 def crawl_definition_files(path, type="definition"):

--- a/micropsi_core/tests/test_runtime_nodes.py
+++ b/micropsi_core/tests/test_runtime_nodes.py
@@ -195,31 +195,31 @@ def test_node_parameters_none(fixed_nodenet):
     assert node.get_parameter('timeout') == 0
 
 
-def test_get_userscripts(fixed_nodenet, resourcepath):
+def test_get_recipes(fixed_nodenet, resourcepath):
     from os import path, remove
-    with open(path.join(resourcepath, 'scripts.py'), 'w') as fp:
+    with open(path.join(resourcepath, 'recipes.py'), 'w') as fp:
         fp.write("""
 def testfoo(netapi, count=23):
     return count
 """)
     micropsi.reload_native_modules(fixed_nodenet)
-    scripts = micropsi.get_available_userscripts()
-    assert 'testfoo' in scripts
-    assert len(scripts['testfoo']['parameters']) == 1
-    assert scripts['testfoo']['parameters'][0]['name'] == 'count'
-    assert scripts['testfoo']['parameters'][0]['default'] == 23
-    remove(path.join(resourcepath, 'scripts.py'))
+    recipes = micropsi.get_available_recipes()
+    assert 'testfoo' in recipes
+    assert len(recipes['testfoo']['parameters']) == 1
+    assert recipes['testfoo']['parameters'][0]['name'] == 'count'
+    assert recipes['testfoo']['parameters'][0]['default'] == 23
+    remove(path.join(resourcepath, 'recipes.py'))
 
 
-def test_run_userscript(fixed_nodenet, resourcepath):
+def test_run_recipe(fixed_nodenet, resourcepath):
     from os import path, remove
-    with open(path.join(resourcepath, 'scripts.py'), 'w') as fp:
+    with open(path.join(resourcepath, 'recipes.py'), 'w') as fp:
         fp.write("""
 def testfoo(netapi, count=23):
     return count
 """)
     micropsi.reload_native_modules(fixed_nodenet)
-    state, result = micropsi.run_userscript(fixed_nodenet, 'testfoo', {'count': 42})
+    state, result = micropsi.run_recipe(fixed_nodenet, 'testfoo', {'count': 42})
     assert state
     assert result == 42
-    remove(path.join(resourcepath, 'scripts.py'))
+    remove(path.join(resourcepath, 'recipes.py'))

--- a/micropsi_core/tests/test_runtime_nodes.py
+++ b/micropsi_core/tests/test_runtime_nodes.py
@@ -193,3 +193,33 @@ def test_node_parameters_none(fixed_nodenet):
     micropsi.set_node_parameters(fixed_nodenet, node.uid, {'response': '', 'timeout': 0})
     assert node.get_parameter('response') is None
     assert node.get_parameter('timeout') == 0
+
+
+def test_get_userscripts(fixed_nodenet, resourcepath):
+    from os import path, remove
+    with open(path.join(resourcepath, 'scripts.py'), 'w') as fp:
+        fp.write("""
+def testfoo(netapi, count=23):
+    return count
+""")
+    micropsi.reload_native_modules(fixed_nodenet)
+    scripts = micropsi.get_available_userscripts()
+    assert 'testfoo' in scripts
+    assert len(scripts['testfoo']['parameters']) == 1
+    assert scripts['testfoo']['parameters'][0]['name'] == 'count'
+    assert scripts['testfoo']['parameters'][0]['default'] == 23
+    remove(path.join(resourcepath, 'scripts.py'))
+
+
+def test_run_userscript(fixed_nodenet, resourcepath):
+    from os import path, remove
+    with open(path.join(resourcepath, 'scripts.py'), 'w') as fp:
+        fp.write("""
+def testfoo(netapi, count=23):
+    return count
+""")
+    micropsi.reload_native_modules(fixed_nodenet)
+    state, result = micropsi.run_userscript(fixed_nodenet, 'testfoo', {'count': 42})
+    assert state
+    assert result == 42
+    remove(path.join(resourcepath, 'scripts.py'))

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -687,7 +687,6 @@ def show_face():
     return template("viewer", mode="face", user_id=user_id, permissions=permissions, token=token, version=VERSION)
 
 
-
 #################################################################
 #
 #
@@ -712,6 +711,7 @@ def load_nodenet(nodenet_uid, nodespace='Root', coordinates={}):
     if result:
         data = runtime.get_nodenet_data(nodenet_uid, nodespace, coordinates)
         data['nodetypes'] = runtime.get_available_node_types(nodenet_uid)
+        data['scripts'] = runtime.get_available_userscripts()
         return True, data
     else:
         return False, uid
@@ -1159,6 +1159,18 @@ def get_logger_messages(logger=[], after=0):
 def get_monitoring_info(nodenet_uid, logger=[], after=0):
     data = runtime.get_monitoring_info(nodenet_uid, logger, after)
     return True, data
+
+
+# --- user scripts ---
+
+@rpc("run_userscript")
+def run_userscript(nodenet_uid, name, parameters):
+    return runtime.run_userscript(nodenet_uid, name, parameters)
+
+
+@rpc('get_available_userscripts')
+def get_available_userscripts():
+    return True, runtime.get_available_userscripts()
 
 
 # -----------------------------------------------------------------------------------------------

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -711,7 +711,7 @@ def load_nodenet(nodenet_uid, nodespace='Root', coordinates={}):
     if result:
         data = runtime.get_nodenet_data(nodenet_uid, nodespace, coordinates)
         data['nodetypes'] = runtime.get_available_node_types(nodenet_uid)
-        data['scripts'] = runtime.get_available_userscripts()
+        data['recipes'] = runtime.get_available_recipes()
         return True, data
     else:
         return False, uid
@@ -1163,14 +1163,14 @@ def get_monitoring_info(nodenet_uid, logger=[], after=0):
 
 # --- user scripts ---
 
-@rpc("run_userscript")
-def run_userscript(nodenet_uid, name, parameters):
-    return runtime.run_userscript(nodenet_uid, name, parameters)
+@rpc("run_recipe")
+def run_recipe(nodenet_uid, name, parameters):
+    return runtime.run_recipe(nodenet_uid, name, parameters)
 
 
-@rpc('get_available_userscripts')
-def get_available_userscripts():
-    return True, runtime.get_available_userscripts()
+@rpc('get_available_recipes')
+def get_available_recipes():
+    return True, runtime.get_available_recipes()
 
 
 # -----------------------------------------------------------------------------------------------

--- a/micropsi_server/static/css/micropsi-styles.css
+++ b/micropsi_server/static/css/micropsi-styles.css
@@ -167,7 +167,7 @@ h3 {
 
 .notifications {
   position: fixed;
-  z-index: 1050;
+  z-index: 1060;
 }
 
 /* Positioning */

--- a/micropsi_server/static/js/dialogs.js
+++ b/micropsi_server/static/js/dialogs.js
@@ -394,15 +394,15 @@ $(function() {
     });
 
 
-    var userscripts = {};
-    var script_name_input = $('#script_name_input');
+    var recipes = {};
+    var recipe_name_input = $('#recipe_name_input');
 
-    var update_parameters_for_userscript = function(){
-        var name = script_name_input.val();
-        if(name in userscripts){
+    var update_parameters_for_recipe = function(){
+        var name = recipe_name_input.val();
+        if(name in recipes){
             var html = '';
-            for(var i in userscripts[name].parameters){
-                var param = userscripts[name].parameters[i];
+            for(var i in recipes[name].parameters){
+                var param = recipes[name].parameters[i];
                 html += '' +
                 '<div class="control-group">'+
                     '<label class="control-label" for="params_'+param.name+'_input">'+param.name+'</label>'+
@@ -411,12 +411,12 @@ $(function() {
                     '</div>'+
                 '</div>';
             }
-            $('.script_param_container').html(html);
+            $('.recipe_param_container').html(html);
         }
     };
 
-    var run_userscript = function(){
-        var form = $('#userscript_modal form');
+    var run_recipe = function(){
+        var form = $('#recipe_modal form');
         data = form.serializeArray();
         parameters = {};
         for(var i=0; i < data.length; i++){
@@ -424,29 +424,29 @@ $(function() {
                 parameters[data[i].name] = data[i].value
             }
         }
-        api.call('run_userscript', {
+        api.call('run_recipe', {
             'nodenet_uid': currentNodenet,
-            'name': script_name_input.val(),
+            'name': recipe_name_input.val(),
             'parameters': parameters,
         }, function(data){
             window.location.reload();
         });
     };
 
-    script_name_input.on('change', update_parameters_for_userscript);
-    $('#userscript_modal .btn-primary').on('click', run_userscript);
-    $('#userscript_modal form').on('submit', run_userscript);
+    recipe_name_input.on('change', update_parameters_for_recipe);
+    $('#recipe_modal .btn-primary').on('click', run_recipe);
+    $('#recipe_modal form').on('submit', run_recipe);
 
-    $('.run_userscript').on('click', function(event){
-        $('#userscript_modal').modal('show');
-        api.call('get_available_userscripts', {}, function(data){
-            userscripts = data;
+    $('.run_recipe').on('click', function(event){
+        $('#recipe_modal').modal('show');
+        api.call('get_available_recipes', {}, function(data){
+            recipes = data;
             var options = '';
             for(var key in data){
                 options += '<option>' + data[key].name + '</option>';
             }
-            script_name_input.html(options);
-            update_parameters_for_userscript();
+            recipe_name_input.html(options);
+            update_parameters_for_recipe();
         });
     });
 

--- a/micropsi_server/static/js/dialogs.js
+++ b/micropsi_server/static/js/dialogs.js
@@ -420,7 +420,7 @@ $(function() {
         data = form.serializeArray();
         parameters = {};
         for(var i=0; i < data.length; i++){
-            if(data[i].name.substr(0, 7) == 'params_'){
+            if(data[i].name != 'recipe_name_input'){
                 parameters[data[i].name] = data[i].value
             }
         }

--- a/micropsi_server/static/js/dialogs.js
+++ b/micropsi_server/static/js/dialogs.js
@@ -393,6 +393,63 @@ $(function() {
         });
     });
 
+
+    var userscripts = {};
+    var script_name_input = $('#script_name_input');
+
+    var update_parameters_for_userscript = function(){
+        var name = script_name_input.val();
+        if(name in userscripts){
+            var html = '';
+            for(var i in userscripts[name].parameters){
+                var param = userscripts[name].parameters[i];
+                html += '' +
+                '<div class="control-group">'+
+                    '<label class="control-label" for="params_'+param.name+'_input">'+param.name+'</label>'+
+                    '<div class="controls">'+
+                        '<input type="text" name="'+param.name+'" class="input-xlarge" id="params_'+param.name+'_input" value="'+(param.default || '')+'"/>'+
+                    '</div>'+
+                '</div>';
+            }
+            $('.script_param_container').html(html);
+        }
+    };
+
+    var run_userscript = function(){
+        var form = $('#userscript_modal form');
+        data = form.serializeArray();
+        parameters = {};
+        for(var i=0; i < data.length; i++){
+            if(data[i].name.substr(0, 7) == 'params_'){
+                parameters[data[i].name] = data[i].value
+            }
+        }
+        api.call('run_userscript', {
+            'nodenet_uid': currentNodenet,
+            'name': script_name_input.val(),
+            'parameters': parameters,
+        }, function(data){
+            window.location.reload();
+        });
+    };
+
+    script_name_input.on('change', update_parameters_for_userscript);
+    $('#userscript_modal .btn-primary').on('click', run_userscript);
+    $('#userscript_modal form').on('submit', run_userscript);
+
+    $('.run_userscript').on('click', function(event){
+        $('#userscript_modal').modal('show');
+        api.call('get_available_userscripts', {}, function(data){
+            userscripts = data;
+            var options = '';
+            for(var key in data){
+                options += '<option>' + data[key].name + '</option>';
+            }
+            script_name_input.html(options);
+            update_parameters_for_userscript();
+        });
+    });
+
 });
 
 

--- a/micropsi_server/tests/conftest.py
+++ b/micropsi_server/tests/conftest.py
@@ -43,8 +43,8 @@ def nodefunc_def():
 
 
 @pytest.fixture
-def scripts_def():
-    return os.path.join(configuration.RESOURCE_PATH, 'scripts.py')
+def recipes_def():
+    return os.path.join(configuration.RESOURCE_PATH, 'recipes.py')
 
 
 def set_logging_levels():

--- a/micropsi_server/tests/conftest.py
+++ b/micropsi_server/tests/conftest.py
@@ -42,6 +42,11 @@ def nodefunc_def():
     return os.path.join(configuration.RESOURCE_PATH, 'nodefunctions.py')
 
 
+@pytest.fixture
+def scripts_def():
+    return os.path.join(configuration.RESOURCE_PATH, 'scripts.py')
+
+
 def set_logging_levels():
     logging.getLogger('system').setLevel(logging.WARNING)
     logging.getLogger('world').setLevel(logging.WARNING)

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -1062,15 +1062,15 @@ def test_500(app):
     assert response.json_body['traceback'] is not None
 
 
-def test_get_userscripts(app, test_nodenet, scripts_def):
+def test_get_recipes(app, test_nodenet, recipes_def):
     app.set_auth()
-    with open(scripts_def, 'w') as fp:
+    with open(recipes_def, 'w') as fp:
         fp.write("""
 def foobar(netapi, quatsch=23):
     return quatsch
 """)
     response = app.get_json('/rpc/reload_native_modules(nodenet_uid="%s")' % test_nodenet)
-    response = app.get_json('/rpc/get_available_userscripts()')
+    response = app.get_json('/rpc/get_available_recipes()')
     data = response.json_body['data']
     assert 'foobar' in data
     assert len(data['foobar']['parameters']) == 1

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -1078,6 +1078,25 @@ def foobar(netapi, quatsch=23):
     assert data['foobar']['parameters'][0]['default'] == 23
 
 
+def test_run_recipes(app, test_nodenet, recipes_def):
+    app.set_auth()
+    with open(recipes_def, 'w') as fp:
+        fp.write("""
+def foobar(netapi, quatsch=23):
+    return quatsch
+""")
+    response = app.get_json('/rpc/reload_native_modules(nodenet_uid="%s")' % test_nodenet)
+    response = app.post_json('/rpc/run_recipe', {
+        'nodenet_uid': test_nodenet,
+        'name': 'foobar',
+        'parameters': {
+            'quatsch': ''
+        }
+    })
+    data = response.json_body['data']
+    assert data == 23
+
+
 def test_nodenet_data_structure(app, test_nodenet, nodetype_def, nodefunc_def):
     app.set_auth()
     from micropsi_core.nodenet.node import Nodetype

--- a/micropsi_server/tests/test_json_api.py
+++ b/micropsi_server/tests/test_json_api.py
@@ -1062,6 +1062,22 @@ def test_500(app):
     assert response.json_body['traceback'] is not None
 
 
+def test_get_userscripts(app, test_nodenet, scripts_def):
+    app.set_auth()
+    with open(scripts_def, 'w') as fp:
+        fp.write("""
+def foobar(netapi, quatsch=23):
+    return quatsch
+""")
+    response = app.get_json('/rpc/reload_native_modules(nodenet_uid="%s")' % test_nodenet)
+    response = app.get_json('/rpc/get_available_userscripts()')
+    data = response.json_body['data']
+    assert 'foobar' in data
+    assert len(data['foobar']['parameters']) == 1
+    assert data['foobar']['parameters'][0]['name'] == 'quatsch'
+    assert data['foobar']['parameters'][0]['default'] == 23
+
+
 def test_nodenet_data_structure(app, test_nodenet, nodetype_def, nodefunc_def):
     app.set_auth()
     from micropsi_core.nodenet.node import Nodetype

--- a/micropsi_server/view/dialogs.tpl
+++ b/micropsi_server/view/dialogs.tpl
@@ -62,23 +62,23 @@
     </div>
 </div>
 
-<div class="modal hide" id="userscript_modal">
+<div class="modal hide" id="recipe_modal">
     <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal">×</button>
-        <h3>Run Script</h3>
+        <h3>Run Recipe</h3>
     </div>
     <div class="modal-body">
-        <p>You can place a python file with useful functions called "scripts.py" in your ressource-directory (next to nodefunctions.py) and run them via this dialog. All functions must have the netapi as their first mandatory parameter, and can define additional parameters which you can then specify in this dialog</p>
+        <p>You can place a python file with useful functions called "recipes.py" in your ressource-directory (next to nodefunctions.py) and run them via this dialog. All functions must have the netapi as their first mandatory parameter, and can define additional parameters which you can then specify in this dialog</p>
         <form class="form-horizontal">
             <fieldset>
                 <div class="control-group">
-                    <label class="control-label" for="script_name_input">Name</label>
+                    <label class="control-label" for="recipe_name_input">Name</label>
                     <div class="controls">
-                        <select name="script_name_input" class="input-xlarge" id="script_name_input"></select>
+                        <select name="recipe_name_input" class="input-xlarge" id="recipe_name_input"></select>
                     </div>
                 </div>
             </fieldset>
-            <fieldset class="script_param_container">
+            <fieldset class="recipe_param_container">
             </fieldset>
         </form>
     </div>

--- a/micropsi_server/view/dialogs.tpl
+++ b/micropsi_server/view/dialogs.tpl
@@ -61,3 +61,29 @@
         <button class="btn btn-primary">Save</button>
     </div>
 </div>
+
+<div class="modal hide" id="userscript_modal">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">×</button>
+        <h3>Run Script</h3>
+    </div>
+    <div class="modal-body">
+        <p>You can place a python file with useful functions called "scripts.py" in your ressource-directory (next to nodefunctions.py) and run them via this dialog. All functions must have the netapi as their first mandatory parameter, and can define additional parameters which you can then specify in this dialog</p>
+        <form class="form-horizontal">
+            <fieldset>
+                <div class="control-group">
+                    <label class="control-label" for="script_name_input">Name</label>
+                    <div class="controls">
+                        <select name="script_name_input" class="input-xlarge" id="script_name_input"></select>
+                    </div>
+                </div>
+            </fieldset>
+            <fieldset class="script_param_container">
+            </fieldset>
+        </form>
+    </div>
+    <div class="modal-footer">
+        <button class="btn" data-dismiss="modal">Close</button>
+        <button class="btn btn-primary">Run</button>
+    </div>
+</div>

--- a/micropsi_server/view/menu.tpl
+++ b/micropsi_server/view/menu.tpl
@@ -20,6 +20,8 @@
                         <li><a href="#" class="nodenet_revert">Revert</a></li>
                         <li><a href="#" class="reload_native_modules">Reload Native Modules</a></li>
                         <li class="divider"></li>
+                        <li><a href="#" class="run_userscript">Run a script</a></li>
+                        <li class="divider"></li>
                         <li><a href="/nodenet/export" class="nodenet_export">Export to file...</a></li>
                         <li><a href="/nodenet/import" class="nodenet_import">Import from file...</a></li>
                         <li><a href="/nodenet/merge" class="nodenet_merge">Merge with file...</a></li>

--- a/micropsi_server/view/menu.tpl
+++ b/micropsi_server/view/menu.tpl
@@ -18,9 +18,9 @@
                         <li><a href="#" class="nodenet_delete">Delete</a></li>
                         <li><a href="#" class="nodenet_save">Save</a></li>
                         <li><a href="#" class="nodenet_revert">Revert</a></li>
-                        <li><a href="#" class="reload_native_modules">Reload Native Modules</a></li>
                         <li class="divider"></li>
                         <li><a href="#" class="run_recipe">Run a recipe</a></li>
+                        <li><a href="#" class="reload_native_modules">Reload Native Modules</a></li>
                         <li class="divider"></li>
                         <li><a href="/nodenet/export" class="nodenet_export">Export to file...</a></li>
                         <li><a href="/nodenet/import" class="nodenet_import">Import from file...</a></li>

--- a/micropsi_server/view/menu.tpl
+++ b/micropsi_server/view/menu.tpl
@@ -20,7 +20,7 @@
                         <li><a href="#" class="nodenet_revert">Revert</a></li>
                         <li><a href="#" class="reload_native_modules">Reload Native Modules</a></li>
                         <li class="divider"></li>
-                        <li><a href="#" class="run_userscript">Run a script</a></li>
+                        <li><a href="#" class="run_recipe">Run a recipe</a></li>
                         <li class="divider"></li>
                         <li><a href="/nodenet/export" class="nodenet_export">Export to file...</a></li>
                         <li><a href="/nodenet/import" class="nodenet_import">Import from file...</a></li>


### PR DESCRIPTION
Quite basic scripts feature: 
The user's resource path (where nodefunctions.py and nodetypes.json reside) is searched for a file called `recipes.py`. If this file exists, every function in that file is read, and offered in the frontend to be run as a one-time recipe, independent of the nodenet-steps.
The recipes can have parameters, which can be specified in the frontend when running the them. The first parameter is always the netapi.
The recipe file is re-read when the user calls 'reload native modules'

Current issues: Dynamic Typing: scripts will have to cast to ints or floats if needed. We could infer the type from the parameter-default, but that doesn't work for `None`-defaults.
