### PR TITLE
gen loops for pipes need sub to stay active now

### DIFF
--- a/micropsi_core/nodenet/nodefunctions.py
+++ b/micropsi_core/nodenet/nodefunctions.py
@@ -124,7 +124,7 @@ def pipe(netapi, node=None, sheaf="default", **params):
         gen += node.get_slot("sur").get_activation(sheaf)
         gen += node.get_slot("exp").get_activation(sheaf)
     else:
-        gen += node.get_slot("gen").get_activation(sheaf)
+        gen += node.get_slot("gen").get_activation(sheaf) * node.get_slot("sub").get_activation(sheaf)
         if abs(gen) < 0.1: gen = 0                                          # cut off gen loop at lower threshold
 
     # commented: trigger and pipes should be able to escape the [-1;1] cage on gen
@@ -141,7 +141,7 @@ def pipe(netapi, node=None, sheaf="default", **params):
 
     sur += node.get_slot("sur").get_activation(sheaf)
     if sur == 0: sur += node.get_slot("sur").get_activation("default")      # no activation in our sheaf, maybe from sensors?
-    if abs(node.get_slot("gen").get_activation(sheaf)) > 0.2:               # cut off sur-reports from gen looping before the loop fades away
+    if abs(node.get_slot("gen").get_activation(sheaf) * node.get_slot("sub").get_activation(sheaf)) > 0.2:               # cut off sur-reports from gen looping before the loop fades away
         sur += 1 if node.get_slot("gen").get_activation(sheaf) > 0 else -1
     sur += node.get_slot("exp").get_activation(sheaf)
 
@@ -173,7 +173,6 @@ def pipe(netapi, node=None, sheaf="default", **params):
     if por > 0: por = 1
 
     ret += node.get_slot("ret").get_activation(sheaf) if node.get_slot("sub").get_activation(sheaf) == 0 and node.get_slot("sur").get_activation(sheaf) == 0 else 0
-    ret -= node.get_slot("por").get_activation(sheaf)
     if node.get_slot("por").get_activation(sheaf) >= 0:
         ret -= node.get_slot("sub").get_activation(sheaf)
     if ret > 1:


### PR DESCRIPTION
This changes the behavior of gen loops in pipes.
So far, when a gen loop was looping, it looped until it had petered out, or forever.
With this change, gen loops will only loop when sub request activation is present. Scripts can contain gen loops with weights of 1 and be sure that they will go back to zero-equilibrium when the executing code loses interest.

This enables script creators to differentiate between "synchronous causal por" and "diachronous temporal por":
- For synchronous causal por "I want the precondition to be actively supported by sur-evidence for the por-linked condition to be true", use simple por
- For diachronous temporal por "should become active after precondition has been checked and found to be true, don't care about its state afterwards", use por and a gen loop on the precondition.