### PR TITLE
Visual patch replay

### DIFF
--- a/micropsi_core/nodenet/theano_engine/theano_nodenet.py
+++ b/micropsi_core/nodenet/theano_engine/theano_nodenet.py
@@ -1064,9 +1064,8 @@ class TheanoNodenet(Nodenet):
         w_matrix = self.w.get_value(borrow=True, return_internal_type=True)
         grp_from = self.nodegroups[group_from]
         grp_to = self.nodegroups[group_to]
-        for row_index in range(len(grp_to)):
-            for col_index in range(len(grp_from)):
-                w_matrix[grp_to[row_index],grp_from[col_index]] = new_w[row_index, col_index]
+        cols, rows = np.meshgrid(grp_from, grp_to)
+        w_matrix[rows, cols] = new_w
         self.w.set_value(w_matrix, borrow=True)
 
     def get_available_gatefunctions(self):

--- a/micropsi_core/nodenet/theano_engine/theano_stepoperators.py
+++ b/micropsi_core/nodenet/theano_engine/theano_stepoperators.py
@@ -228,10 +228,11 @@ class TheanoCalculate(Calculate):
             nodenet.has_new_usages = False
 
         self.write_actuators()
+        self.read_sensors_and_actuator_feedback()
         self.calculate_native_modules()
 
         self.nodenet.rebuild_shifted()
 
         self.calculate()
-        self.read_sensors_and_actuator_feedback()
+#        self.read_sensors_and_actuator_feedback()
 

--- a/micropsi_core/nodenet/theano_engine/theano_stepoperators.py
+++ b/micropsi_core/nodenet/theano_engine/theano_stepoperators.py
@@ -168,7 +168,7 @@ class TheanoCalculate(Calculate):
             gate_function_output = T.switch(T.eq(nodenet.g_function_selector, GATE_FUNCTION_ABSOLUTE), abs(gate_function_output), gate_function_output)
         # apply GATE_FUNCTION_SIGMOID to masked gates
         if nodenet.has_gatefunction_sigmoid:
-            gate_function_output = T.switch(T.eq(nodenet.g_function_selector, GATE_FUNCTION_SIGMOID), N.sigmoid(gate_function_output - nodenet.g_theta), gate_function_output)
+            gate_function_output = T.switch(T.eq(nodenet.g_function_selector, GATE_FUNCTION_SIGMOID), N.sigmoid(gate_function_output + nodenet.g_theta), gate_function_output)
         # apply GATE_FUNCTION_TANH to masked gates
         if nodenet.has_gatefunction_tanh:
             gate_function_output = T.switch(T.eq(nodenet.g_function_selector, GATE_FUNCTION_TANH), T.tanh(gate_function_output - nodenet.g_theta), gate_function_output)
@@ -229,10 +229,9 @@ class TheanoCalculate(Calculate):
 
         self.write_actuators()
         self.read_sensors_and_actuator_feedback()
-        self.calculate_native_modules()
 
         self.nodenet.rebuild_shifted()
 
         self.calculate()
-#        self.read_sensors_and_actuator_feedback()
 
+        self.calculate_native_modules()

--- a/micropsi_core/world/minecraft/minecraft_graph_locomotion.py
+++ b/micropsi_core/world/minecraft/minecraft_graph_locomotion.py
@@ -589,24 +589,24 @@ class MinecraftGraphLocomotion(WorldAdapter):
             # scale from [-1,+1] to [0.1,0.9] and write values to sensors
             patch_resc = [(1.0 + x) * 0.4 + 0.1 for x in patch_std]
 
-        self.write_visual_input_to_datasources(patch_resc)
+        self.write_visual_input_to_datasources(patch_resc, self.patch_width, self.patch_height)
 
     def simulate_visual_input(self):
         if self.world.current_step % 4 == 0:
             entry_index = (self.world.current_step / 4) % len(self.simulated_vision_data)
             if entry_index == 0:
                 self.logger.info("Simulating vision from data file with %i entries...", len(self.simulated_vision_data))
-            self.write_visual_input_to_datasources(self.simulated_vision_data[entry_index])
+            self.write_visual_input_to_datasources(self.simulated_vision_data[entry_index], self.num_fov, self.num_fov)
 
-    def write_visual_input_to_datasources(self, patch):
+    def write_visual_input_to_datasources(self, patch, patch_width, patch_height):
         # write values to self.datasources['fov__']
         # if num_fov < patch height and width, write the left-right centered, top-bottom 3/4 chunk to fov__
-        left_rim = (int(self.patch_width - self.num_fov) // 2) - 1
-        top_rim = (int(self.patch_height - self.num_fov) // 4 * 3) - 1
+        left_rim = (int(patch_width - self.num_fov) // 2) - 1
+        top_rim = (int(patch_height - self.num_fov) // 4 * 3) - 1
         for i in range(self.num_fov):
             for j in range(self.num_fov):
                 name = 'fov__%02d_%02d' % (i, j)
-                self.datasources[name] = patch[(self.patch_height * (i + top_rim)) + j + left_rim]
+                self.datasources[name] = patch[(patch_height * (i + top_rim)) + j + left_rim]
 
     def project(self, xi, yi, zi, x0, y0, z0, yaw, pitch):
         """

--- a/micropsi_core/world/minecraft/minecraft_graph_locomotion.py
+++ b/micropsi_core/world/minecraft/minecraft_graph_locomotion.py
@@ -338,8 +338,8 @@ class MinecraftGraphLocomotion(WorldAdapter):
             # make sure fovea datasources don't go below 0.
             self.datasources['fov_x'] = self.datatargets['fov_x'] - 1. if self.datatargets['fov_x'] > 0. else 0.
             self.datasources['fov_y'] = self.datatargets['fov_y'] - 1. if self.datatargets['fov_y'] > 0. else 0.
-            loco_label = self.current_loco_node['name']  # because python uses call-by-object
             if not self.simulated_vision:
+                loco_label = self.current_loco_node['name']  # because python uses call-by-object
                 self.get_visual_input(self.datasources['fov_x'], self.datasources['fov_y'], loco_label)
             else:
                 self.simulate_visual_input()

--- a/micropsi_core/world/minecraft/minecraft_graph_locomotion.py
+++ b/micropsi_core/world/minecraft/minecraft_graph_locomotion.py
@@ -593,8 +593,9 @@ class MinecraftGraphLocomotion(WorldAdapter):
 
     def simulate_visual_input(self):
         if self.world.current_step % 4 == 0:
-            print("Simulating vision in world step "+str(self.world.current_step))
             entry_index = (self.world.current_step / 4) % len(self.simulated_vision_data)
+            if entry_index == 0:
+                self.logger.info("Simulating vision from data file with %i entries...", len(self.simulated_vision_data))
             self.write_visual_input_to_datasources(self.simulated_vision_data[entry_index])
 
     def write_visual_input_to_datasources(self, patch):


### PR DESCRIPTION
This PR contains features and fixes for autoencoder learning in the theano_engine:

- an addition to the graph locomotion world adapter that can replay visual patches from CSV files instead of using current data
- setting weights is much faster
- native modules now see menaingful activation values