### PR TITLE
theano_engine configuation and gpu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Run with Theano
 * To run micropsi with an optional and experimental node net implementation based on Theano, you need to install Theano
 * Call 'make' after checkout
 * Call 'source bin/activate'
-* Follow Theano's "bleeding edge install instructions" directions at [here](http://deeplearning.net/software/theano/install.html)
+* Follow Theano's "bleeding edge install instructions" directions [here](http://deeplearning.net/software/theano/install.html)
 * When creating a new node net, you should now be able to chose theano_engine
 
 Tests

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Run with Minecraft
 * Also see [micropsi_core/world/minecraft/README.md](/micropsi_core/world/minecraft/README.md) for setup instructions.
 
 
+Run with theano
+-----
+* To run micropsi with an optional and experimental node net implementation based on theano, you need to install theano
+* Call 'make' after checkout
+* Call 'source bin/activate'
+* Follow theano's "bleeding edge install instructions" directions at [here](http://deeplearning.net/software/theano/install.html)
+* When creating a new node net, you should now be able to chose theano_engine
+
 Tests
 -----
 * To run the tests type `make tests`

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Run with Minecraft
 * Also see [micropsi_core/world/minecraft/README.md](/micropsi_core/world/minecraft/README.md) for setup instructions.
 
 
-Run with theano
+Run with Theano
 -----
-* To run micropsi with an optional and experimental node net implementation based on theano, you need to install theano
+* To run micropsi with an optional and experimental node net implementation based on Theano, you need to install Theano
 * Call 'make' after checkout
 * Call 'source bin/activate'
-* Follow theano's "bleeding edge install instructions" directions at [here](http://deeplearning.net/software/theano/install.html)
+* Follow Theano's "bleeding edge install instructions" directions at [here](http://deeplearning.net/software/theano/install.html)
 * When creating a new node net, you should now be able to chose theano_engine
 
 Tests
@@ -45,3 +45,4 @@ Attribution
 * [spock](https://github.com/nickelpro/spock)
 * [paperjs](http://github.com/paperjs/paper.js)
 * [three.js](https://github.com/mrdoob/three.js)
+* [theano](git://github.com/Theano/Theano)

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ Attribution
 * [spock](https://github.com/nickelpro/spock)
 * [paperjs](http://github.com/paperjs/paper.js)
 * [three.js](https://github.com/mrdoob/three.js)
-* [theano](git://github.com/Theano/Theano)
+* [theano](https://github.com/Theano/Theano)

--- a/config.ini.template
+++ b/config.ini.template
@@ -38,3 +38,9 @@ port = 25565
 level_system = WARNING
 level_world = WARNING
 level_nodenet = WARNING
+
+[theano]
+
+# floating point precision for theano_engine. 32 or 64.
+precision = 32
+cuda_root = /Developer/NVIDIA/CUDA-7.0/

--- a/config.ini.template
+++ b/config.ini.template
@@ -43,4 +43,6 @@ level_nodenet = WARNING
 
 # floating point precision for theano_engine. 32 or 64.
 precision = 32
-cuda_root = /Developer/NVIDIA/CUDA-7.0/
+
+# use sparse weight matrix. True or False.
+sparse_weight_matrix = True

--- a/micropsi_core/nodenet/theano_engine/theano_node.py
+++ b/micropsi_core/nodenet/theano_engine/theano_node.py
@@ -568,7 +568,7 @@ class TheanoGate(Gate):
 
     def get_links(self):
         links = []
-        w_matrix = self.__nodenet.w.get_value(borrow=True, return_internal_type=True)
+        w_matrix = self.__nodenet.w.get_value(borrow=True)
         gatecolumn = w_matrix[:, self.__nodenet.allocated_node_offsets[from_id(self.__node.uid)] + self.__numerictype]
         links_indices = np.nonzero(gatecolumn)[0]
         for index in links_indices:
@@ -645,7 +645,7 @@ class TheanoSlot(Slot):
 
     def get_links(self):
         links = []
-        w_matrix = self.__nodenet.w.get_value(borrow=True, return_internal_type=True)
+        w_matrix = self.__nodenet.w.get_value(borrow=True)
         slotrow = w_matrix[self.__nodenet.allocated_node_offsets[from_id(self.__node.uid)] + self.__numerictype]
         if self.__nodenet.sparse:
             links_indices = np.nonzero(slotrow)[1]

--- a/micropsi_core/nodenet/theano_engine/theano_node.py
+++ b/micropsi_core/nodenet/theano_engine/theano_node.py
@@ -309,7 +309,7 @@ class TheanoNode(Node):
 
     @activation.setter
     def activation(self, activation):
-        a_array = self._nodenet.a.get_value(borrow=True, return_internal_type=True)
+        a_array = self._nodenet.a.get_value(borrow=True)
         a_array[self._nodenet.allocated_node_offsets[self._id] + GEN] = activation
         self._nodenet.a.set_value(a_array, borrow=True)
 

--- a/micropsi_core/nodenet/theano_engine/theano_nodenet.py
+++ b/micropsi_core/nodenet/theano_engine/theano_nodenet.py
@@ -338,11 +338,12 @@ class TheanoNodenet(Nodenet):
             numpyfloatX = np.float64
             self.byte_per_float = 8
 
-        cuda_root = None
-        if "CUDA_ROOT" in os.environ:
-            cuda_root = os.environ['CUDA_ROOT']
-        if cuda_root is not None:
-            self.logger.info("Configuring theano to use CUDA with cuda_root=%s", cuda_root)
+        device = T.config.device
+        self.logger.info("Theano configured to use %s", device)
+        if device.startswith("gpu"):
+            self.logger.info("Using CUDA with cuda_root=%s and theano_flags=%s", os.environ["CUDA_ROOT"], os.environ["THEANO_FLAGS"])
+            if T.config.floatX != "float32":
+                self.logger.warn("Precision set to %s, but using gpu.", precision)
 
         self.netapi = TheanoNetAPI(self)
 

--- a/micropsi_core/nodenet/theano_engine/theano_nodenet.py
+++ b/micropsi_core/nodenet/theano_engine/theano_nodenet.py
@@ -343,8 +343,6 @@ class TheanoNodenet(Nodenet):
             cuda_root = os.environ['CUDA_ROOT']
         if cuda_root is not None:
             self.logger.info("Configuring theano to use CUDA with cuda_root=%s", cuda_root)
-            #T.config.print_active_device=True
-            #T.config.fastmath=True
 
         self.netapi = TheanoNetAPI(self)
 
@@ -1209,7 +1207,7 @@ class TheanoNodenet(Nodenet):
 
         ngt = get_numerical_gate_type(gate_type, source_nodetype)
         nst = get_numerical_slot_type(slot_type, target_nodetype)
-        w_matrix = self.w.get_value(borrow=True, return_internal_type=True)
+        w_matrix = self.w.get_value(borrow=True)
         x = self.allocated_node_offsets[tnode.from_id(target_node_uid)] + nst
         y = self.allocated_node_offsets[tnode.from_id(source_node_uid)] + ngt
         if self.sparse:

--- a/micropsi_core/nodenet/theano_engine/theano_nodenet.py
+++ b/micropsi_core/nodenet/theano_engine/theano_nodenet.py
@@ -462,6 +462,11 @@ class TheanoNodenet(Nodenet):
 
 
         w = self.w.get_value(borrow=True)
+
+        # if we're sparse, convert to sparse matrix for persistency
+        if not self.sparse:
+            w = sp.csr_matrix(w)
+
         a = self.a.get_value(borrow=True)
         g_theta = self.g_theta.get_value(borrow=True)
         g_factor = self.g_factor.get_value(borrow=True)
@@ -612,6 +617,9 @@ class TheanoNodenet(Nodenet):
 
                 if 'w_data' in datafile and 'w_indices' in datafile and 'w_indptr' in datafile:
                     w = sp.csr_matrix((datafile['w_data'], datafile['w_indices'], datafile['w_indptr']), shape = (self.NoE, self.NoE))
+                    # if we're configured to be dense, convert from csr
+                    if not self.sparse:
+                        w = w.todense()
                     self.w = theano.shared(value=w.astype(T.config.floatX), name="w", borrow=False)
                     self.a = theano.shared(value=datafile['a'].astype(T.config.floatX), name="a", borrow=False)
                 else:

--- a/micropsi_core/nodenet/theano_engine/theano_nodenet.py
+++ b/micropsi_core/nodenet/theano_engine/theano_nodenet.py
@@ -1299,7 +1299,7 @@ class TheanoNodenet(Nodenet):
 
     def construct_links_dict(self):
         data = {}
-        w_matrix = self.w.get_value(borrow=True, return_internal_type=True)
+        w_matrix = self.w.get_value(borrow=True)
         for source_id in np.nonzero(self.allocated_nodes)[0]:
             source_type = self.allocated_nodes[source_id]
             for gate_type in range(get_elements_per_type(source_type, self.native_modules)):

--- a/micropsi_core/nodenet/theano_engine/theano_nodenet.py
+++ b/micropsi_core/nodenet/theano_engine/theano_nodenet.py
@@ -343,7 +343,7 @@ class TheanoNodenet(Nodenet):
         if device.startswith("gpu"):
             self.logger.info("Using CUDA with cuda_root=%s and theano_flags=%s", os.environ["CUDA_ROOT"], os.environ["THEANO_FLAGS"])
             if T.config.floatX != "float32":
-                self.logger.warn("Precision set to %s, but using gpu.", precision)
+                self.logger.warn("Precision set to %s, but attempting to use gpu.", precision)
 
         self.netapi = TheanoNetAPI(self)
 

--- a/micropsi_core/nodenet/theano_engine/theano_nodenet.py
+++ b/micropsi_core/nodenet/theano_engine/theano_nodenet.py
@@ -25,6 +25,8 @@ from micropsi_core.nodenet.theano_engine.theano_stepoperators import *
 from micropsi_core.nodenet.theano_engine.theano_nodespace import *
 from micropsi_core.nodenet.theano_engine.theano_netapi import TheanoNetAPI
 
+from configuration import config as settings
+
 
 STANDARD_NODETYPES = {
     "Nodespace": {
@@ -306,13 +308,25 @@ class TheanoNodenet(Nodenet):
 
     def __init__(self, name="", worldadapter="Default", world=None, owner="", uid=None, native_modules={}):
 
-        # todo: move to float32 and handle casting issues on the way back to Python doubles (JSON-serialization...)
-        T.config.floatX = "float32"
-        scipyfloatX = scipy.float32
-        numpyfloatX = np.float32
-        self.byte_per_float = 4
-
         super(TheanoNodenet, self).__init__(name, worldadapter, world, owner, uid)
+
+        precision = settings['theano']['precision']
+        if precision == "32":
+            T.config.floatX = "float32"
+            scipyfloatX = scipy.float32
+            numpyfloatX = np.float32
+            self.byte_per_float = 4
+        elif precision == "64":
+            T.config.floatX = "float64"
+            scipyfloatX = scipy.float64
+            numpyfloatX = np.float64
+            self.byte_per_float = 8
+        else:
+            self.logger.warn("Unsupported precision value from configuration: %s, falling back to float64", precision)
+            T.config.floatX = "float64"
+            scipyfloatX = scipy.float64
+            numpyfloatX = np.float64
+            self.byte_per_float = 8
 
         self.netapi = TheanoNetAPI(self)
 

--- a/micropsi_core/nodenet/theano_engine/theano_stepoperators.py
+++ b/micropsi_core/nodenet/theano_engine/theano_stepoperators.py
@@ -241,7 +241,8 @@ class TheanoCalculate(Calculate):
         self.take_native_module_slot_snapshots()
         self.write_actuators()
         self.read_sensors_and_actuator_feedback()
-        self.nodenet.rebuild_shifted()
+        if nodenet.has_pipes:
+            self.nodenet.rebuild_shifted()
         if nodenet.has_directional_activators:
             self.calculate_g_factors()
         self.calculate()


### PR DESCRIPTION
This PR introduces configuration options (in config.ini) that allows users to chose between single (float32) and double (float64) precision, and between dense and sparse weight matrix implementations.

In addition, if nvidia's CUDA drivers are installed and a compatible GPU is present, setting the environment variables
CUDA_ROOT=/Developer/NVIDIA/CUDA-7.0 and
THEANO_FLAGS=device=gpu0
will move most of the node net calculations to the GPU. 
Note that this doesn't necessarily make things faster. In fact, in most scenarios, right now, it will not, as netapi access happens over PCIe when the data is offloaded to the GPU, so native module and GUI performance will suffer. (Sensor access is untested.)