### PR TITLE
Generate netapi code

### DIFF
--- a/micropsi_core/nodenet/theano_engine/theano_node.py
+++ b/micropsi_core/nodenet/theano_engine/theano_node.py
@@ -264,8 +264,8 @@ class TheanoNode(Node):
             self._nodenet.g_expect.set_value(g_expect_array, borrow=True)
         elif self.type == "Pipe" and parameter == "wait":
             g_wait_array = self._nodenet.g_wait.get_value(borrow=True)
-            g_wait_array[self._nodenet.allocated_node_offsets[self._id] + get_numerical_gate_type("sur")] = int(min(value, 128))
-            g_wait_array[self._nodenet.allocated_node_offsets[self._id] + get_numerical_gate_type("por")] = int(min(value, 128))
+            g_wait_array[self._nodenet.allocated_node_offsets[self._id] + get_numerical_gate_type("sur")] = min(int(value), 128)
+            g_wait_array[self._nodenet.allocated_node_offsets[self._id] + get_numerical_gate_type("por")] = min(int(value), 128)
             self._nodenet.g_wait.set_value(g_wait_array, borrow=True)
         elif self.type == "Comment" and parameter == "comment":
             self.parameters[parameter] = value

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -762,9 +762,9 @@ def generate_netapi_fragment(nodenet_uid, node_uids):
                 if not reciprocal:
                     weight = link.weight if link.weight != 1 else None
                     if weight is not None:
-                        lines.append("netapi.link(%s, %s, %s, %s, %i)" % (source_id, gatetype, target_id, link.target_slot.type, weight))
+                        lines.append("netapi.link(%s, '%s', %s, '%s', %i)" % (source_id, gatetype, target_id, link.target_slot.type, weight))
                     else:
-                        lines.append("netapi.link(%s, %s, %s, %s)" % (source_id, gatetype, target_id, link.target_slot.type))
+                        lines.append("netapi.link(%s, '%s', %s, '%s')" % (source_id, gatetype, target_id, link.target_slot.type))
 
     lines.append("")
 

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -681,7 +681,7 @@ def generate_netapi_fragment(nodenet_uid, node_uids):
         varname = "node%i" % i
 
         if name is not None:
-            if name != "" and len(name) > 3 and name not in idmap.values():
+            if name != "" and name not in idmap.values():
                 varname = __pythonify(name)
             lines.append("%s = netapi.create_node('%s', None, \"%s\")" % (varname, node.type, name))
         else:
@@ -720,49 +720,49 @@ def generate_netapi_fragment(nodenet_uid, node_uids):
                 target_id = idmap[link.target_node.uid]
 
                 reciprocal = False
-                if link.source_gate.type == 'sub' and 'sur' in link.target_node.get_gate_types():
+                if link.source_gate.type == 'sub' and 'sur' in link.target_node.get_gate_types() and link.weight == 1:
                     surgate = link.target_node.get_gate('sur')
-                    for link in surgate.get_links():
-                        if link.target_node.uid == node.uid and link.target_slot.type == 'sur' and link.weight == 1:
+                    for rec_link in surgate.get_links():
+                        if rec_link.target_node.uid == node.uid and rec_link.target_slot.type == 'sur' and rec_link.weight == 1:
                             reciprocal = True
                             lines.append("netapi.link_with_reciprocal(%s, %s, 'subsur')" % (source_id, target_id))
 
-                if link.source_gate.type == 'sur' and 'sub' in link.target_node.get_gate_types():
+                if link.source_gate.type == 'sur' and 'sub' in link.target_node.get_gate_types() and link.weight == 1:
                     subgate = link.target_node.get_gate('sub')
-                    for link in subgate.get_links():
-                        if link.target_node.uid == node.uid and link.target_slot.type == 'sub' and link.weight == 1:
+                    for rec_link in subgate.get_links():
+                        if rec_link.target_node.uid == node.uid and rec_link.target_slot.type == 'sub' and rec_link.weight == 1:
                             reciprocal = True
 
-                if link.source_gate.type == 'por' and 'ret' in link.target_node.get_gate_types():
+                if link.source_gate.type == 'por' and 'ret' in link.target_node.get_gate_types() and link.weight == 1:
                     surgate = link.target_node.get_gate('ret')
-                    for link in surgate.get_links():
-                        if link.target_node.uid == node.uid and link.target_slot.type == 'ret' and link.weight == 1:
+                    for rec_link in surgate.get_links():
+                        if rec_link.target_node.uid == node.uid and rec_link.target_slot.type == 'ret' and rec_link.weight == 1:
                             reciprocal = True
                             lines.append("netapi.link_with_reciprocal(%s, %s, 'porret')" % (source_id, target_id))
 
-                if link.source_gate.type == 'ret' and 'por' in link.target_node.get_gate_types():
+                if link.source_gate.type == 'ret' and 'por' in link.target_node.get_gate_types() and link.weight == 1:
                     subgate = link.target_node.get_gate('por')
-                    for link in subgate.get_links():
-                        if link.target_node.uid == node.uid and link.target_slot.type == 'por' and link.weight == 1:
+                    for rec_link in subgate.get_links():
+                        if rec_link.target_node.uid == node.uid and rec_link.target_slot.type == 'por' and rec_link.weight == 1:
                             reciprocal = True
 
-                if link.source_gate.type == 'cat' and 'exp' in link.target_node.get_gate_types():
+                if link.source_gate.type == 'cat' and 'exp' in link.target_node.get_gate_types() and link.weight == 1:
                     surgate = link.target_node.get_gate('exp')
-                    for link in surgate.get_links():
-                        if link.target_node.uid == node.uid and link.target_slot.type == 'exp' and link.weight == 1:
+                    for rec_link in surgate.get_links():
+                        if rec_link.target_node.uid == node.uid and rec_link.target_slot.type == 'exp' and rec_link.weight == 1:
                             reciprocal = True
                             lines.append("netapi.link_with_reciprocal(%s, %s, 'catexp')" % (source_id, target_id))
 
-                if link.source_gate.type == 'exp' and 'cat' in link.target_node.get_gate_types():
+                if link.source_gate.type == 'exp' and 'cat' in link.target_node.get_gate_types() and link.weight == 1:
                     subgate = link.target_node.get_gate('cat')
-                    for link in subgate.get_links():
-                        if link.target_node.uid == node.uid and link.target_slot.type == 'cat' and link.weight == 1:
+                    for rec_link in subgate.get_links():
+                        if rec_link.target_node.uid == node.uid and rec_link.target_slot.type == 'cat' and rec_link.weight == 1:
                             reciprocal = True
 
                 if not reciprocal:
                     weight = link.weight if link.weight != 1 else None
                     if weight is not None:
-                        lines.append("netapi.link(%s, '%s', %s, '%s', %i)" % (source_id, gatetype, target_id, link.target_slot.type, weight))
+                        lines.append("netapi.link(%s, '%s', %s, '%s', %.8f)" % (source_id, gatetype, target_id, link.target_slot.type, weight))
                     else:
                         lines.append("netapi.link(%s, '%s', %s, '%s')" % (source_id, gatetype, target_id, link.target_slot.type))
 

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -673,7 +673,7 @@ def generate_netapi_fragment(nodenet_uid, node_uids):
     for node in nodes:
         name = node.name if node.name != node.uid else None
         if name is not None:
-            lines.append("node%i = netapi.create_node('%s', None, \"$s\")" % (i, node.type, name))
+            lines.append("node%i = netapi.create_node('%s', None, \"%s\")" % (i, node.type, name))
         else:
             lines.append("node%i = netapi.create_node('%s', None)" % (i, node.type))
         idmap[node.uid] = "node%i" % i

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -685,7 +685,15 @@ def generate_netapi_fragment(nodenet_uid, node_uids):
         ndgps = node.clone_non_default_gate_parameters()
         for gatetype in ndgps.keys():
             for parameter, value in ndgps[gatetype].items():
-                lines.append("%s.set_gate_parameter(%s, %s, %s)" % (varname, gatetype, parameter, value))
+                lines.append("%s.set_gate_parameter('%s', \"%s\", %s)" % (varname, gatetype, parameter, value))
+
+        nps = node.clone_parameters()
+        for parameter, value in nps.items():
+            if parameter not in node.nodetype.parameter_defaults or node.nodetype.parameter_defaults[parameter] != value:
+                if isinstance(value, str):
+                    lines.append("%s.set_parameter(\"%s\”, \"%s\")" % (varname, parameter, value))
+                else:
+                    lines.append("%s.set_parameter(\"%s”, %s)" % (varname, parameter, value))
 
         idmap[node.uid] = varname
         i += 1

--- a/micropsi_core/runtime.py
+++ b/micropsi_core/runtime.py
@@ -690,7 +690,7 @@ def generate_netapi_fragment(nodenet_uid, node_uids):
         ndgps = node.clone_non_default_gate_parameters()
         for gatetype in ndgps.keys():
             for parameter, value in ndgps[gatetype].items():
-                lines.append("%s.set_gate_parameter('%s', \"%s\", %s)" % (varname, gatetype, parameter, value))
+                lines.append("%s.set_gate_parameter('%s', \"%s\", %.2f)" % (varname, gatetype, parameter, value))
 
         nps = node.clone_parameters()
         for parameter, value in nps.items():
@@ -699,9 +699,9 @@ def generate_netapi_fragment(nodenet_uid, node_uids):
 
             if parameter not in node.nodetype.parameter_defaults or node.nodetype.parameter_defaults[parameter] != value:
                 if isinstance(value, str):
-                    lines.append("%s.set_parameter(\"%s\”, \"%s\")" % (varname, parameter, value))
+                    lines.append("%s.set_parameter(\"%s\", \"%s\")" % (varname, parameter, value))
                 else:
-                    lines.append("%s.set_parameter(\"%s”, %s)" % (varname, parameter, value))
+                    lines.append("%s.set_parameter(\"%s\", %.2f)" % (varname, parameter, value))
 
         idmap[node.uid] = varname
         i += 1

--- a/micropsi_server/micropsi_app.py
+++ b/micropsi_server/micropsi_app.py
@@ -1046,6 +1046,9 @@ def delete_node(nodenet_uid, node_uid):
 def align_nodes(nodenet_uid, nodespace):
     return runtime.align_nodes(nodenet_uid, nodespace)
 
+@rpc("generate_netapi_fragment", permission_required="manage nodenets")
+def generate_netapi_fragment(nodenet_uid, node_uids):
+    return True, runtime.generate_netapi_fragment(nodenet_uid, node_uids)
 
 @rpc("get_available_node_types")
 def get_available_node_types(nodenet_uid):

--- a/micropsi_server/static/js/nodenet.js
+++ b/micropsi_server/static/js/nodenet.js
@@ -2530,6 +2530,7 @@ function openMultipleNodesContextMenu(event){
     if(sametype){
         html += '<li class="divider"></li>' + getNodeLinkageContextMenuHTML(node);
     }
+    html += '<li data-generate-fragment><a href="#">Generate netapi fragment</a></li>';
     menu.html(html);
     if(Object.keys(clipboard).length === 0){
         $('#multi_node_menu li[data-paste-nodes]').addClass('disabled');
@@ -2591,6 +2592,9 @@ function handleContextMenu(event) {
     if($el.parent().attr('data-copy-nodes') === ""){
         copyNodes();
         $el.parentsUntil('.dropdown-menu').dropdown('toggle');
+        return;
+    } else if($el.parent().attr('data-generate-fragment') === ""){
+        generateFragment();
         return;
     } else if($el.parent().attr('data-paste-nodes') === ""){
         pasteNodes(clickPosition);
@@ -2871,6 +2875,15 @@ function createNativeModuleHandler(event){
         $('#native_module_name').val('');
         modal.modal("show");
     }
+}
+
+function generateFragment(){
+    api.call("generate_netapi_fragment",
+        {nodenet_uid:currentNodenet, node_uids: selection},
+        success=function(data){
+            window.prompt("Ready for clipboard: ", data);
+        }
+    );
 }
 
 copyPosition = null;


### PR DESCRIPTION
This PR introduces a way to automatically generate fragments of netapi code for recreating selected node net structures.

This is useful for prototyping structures in the graphical editor, then create them programatically from a receipe or native module.

Supported are:
- links, including reciprocal links
- nodes, with names if available and positions relative to the top left-most node
- node and gate parameters

The UI is rudimentary right now - please UXify before merging.